### PR TITLE
fix: clear cache to ensure account changes when changing account

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/example/mobilecomputingassignment/MainActivity.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/MainActivity.kt
@@ -7,9 +7,13 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.mobilecomputingassignment.presentation.ui.screen.MainAppScreen
 import com.example.mobilecomputingassignment.presentation.ui.screen.OnboardingScreen
 import com.example.mobilecomputingassignment.presentation.ui.theme.WatchmatesTheme
+import com.example.mobilecomputingassignment.presentation.viewmodel.AuthViewModel
+import com.example.mobilecomputingassignment.presentation.viewmodel.EventViewModel
+import com.example.mobilecomputingassignment.presentation.viewmodel.ProfileViewModel
 import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -33,9 +37,35 @@ fun WatchMatesApp() {
     val auth = FirebaseAuth.getInstance()
     var currentUser by remember { mutableStateOf(auth.currentUser) }
 
+    // Get ViewModels to clear their cached data on logout
+    val profileViewModel: ProfileViewModel = hiltViewModel()
+    val eventViewModel: EventViewModel = hiltViewModel()
+    val authViewModel: AuthViewModel = hiltViewModel()
+
     // Listen to auth state changes
     LaunchedEffect(Unit) {
-        auth.addAuthStateListener { firebaseAuth -> currentUser = firebaseAuth.currentUser }
+        auth.addAuthStateListener { firebaseAuth ->
+            val newUser = firebaseAuth.currentUser
+            // If user changed (logout or new login), clear cached data
+            if (currentUser != newUser) {
+                if (currentUser != null && newUser == null) {
+                    // User logged out, clear all cached data
+                    android.util.Log.d("MainActivity", "User logged out, clearing cached data")
+                    profileViewModel.clearUserData()
+                    eventViewModel.clearEventData()
+                    authViewModel.clearAuthData()
+                } else if (currentUser == null && newUser != null) {
+                    // New user logged in, refresh data
+                    android.util.Log.d(
+                            "MainActivity",
+                            "New user logged in, refreshing data: ${newUser.uid}"
+                    )
+                    profileViewModel.loadUserProfile()
+                    eventViewModel.loadUserEvents()
+                }
+                currentUser = newUser
+            }
+        }
     }
 
     if (currentUser == null) {
@@ -50,7 +80,7 @@ fun WatchMatesApp() {
         MainAppScreen(
                 onLogout = {
                     auth.signOut()
-                    currentUser = null
+                    // Note: currentUser will be set to null by the auth state listener
                 }
         )
     }

--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/viewmodel/AuthViewModel.kt
@@ -541,6 +541,13 @@ constructor(
                 _uiState.value = _uiState.value.copy(errorMessage = null, isUsernameValid = true)
         }
 
+        // Clear all auth data when logout occurs
+        fun clearAuthData() {
+                android.util.Log.d("AuthViewModel", "Clearing auth data")
+                _uiState.value = AuthUiState()
+                _signupData.value = SignupData()
+        }
+
         private fun isValidEmail(email: String): Boolean {
                 return android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches()
         }

--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/viewmodel/EventViewModel.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/viewmodel/EventViewModel.kt
@@ -524,4 +524,11 @@ constructor(
         fun clearError() {
                 _uiState.value = _uiState.value.copy(errorMessage = null)
         }
+
+        // Clear cached event data when logout occurs
+        fun clearEventData() {
+                android.util.Log.d("EventViewModel", "Clearing event data")
+                _uiState.value = EventUiState()
+                _formData.value = EventFormData()
+        }
 }

--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/viewmodel/ProfileViewModel.kt
@@ -34,16 +34,19 @@ constructor(private val userRepository: UserRepository, private val auth: Fireba
   fun loadUserProfile() {
     val currentUser = auth.currentUser
     if (currentUser == null) {
+      android.util.Log.d("ProfileViewModel", "No authenticated user found")
       _uiState.value =
               _uiState.value.copy(isLoading = false, errorMessage = "User not authenticated")
       return
     }
 
+    android.util.Log.d("ProfileViewModel", "Loading profile for user: ${currentUser.uid}")
     viewModelScope.launch {
       _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
 
       try {
         val user = userRepository.getUserById(currentUser.uid)
+        android.util.Log.d("ProfileViewModel", "Loaded user profile: ${user?.username}")
         _uiState.value =
                 _uiState.value.copy(
                         user = user,
@@ -51,6 +54,7 @@ constructor(private val userRepository: UserRepository, private val auth: Fireba
                         errorMessage = if (user == null) "User profile not found" else null
                 )
       } catch (e: Exception) {
+        android.util.Log.e("ProfileViewModel", "Failed to load profile", e)
         _uiState.value =
                 _uiState.value.copy(
                         isLoading = false,
@@ -62,5 +66,11 @@ constructor(private val userRepository: UserRepository, private val auth: Fireba
 
   fun refreshProfile() {
     loadUserProfile()
+  }
+
+  // Clear cached user data when logout occurs
+  fun clearUserData() {
+    android.util.Log.d("ProfileViewModel", "Clearing user data")
+    _uiState.value = ProfileUiState()
   }
 }


### PR DESCRIPTION
Clear cached ViewModel data on user logout

Added clear methods to AuthViewModel, EventViewModel, and ProfileViewModel to reset cached data when a user logs out. MainActivity now listens for authentication state changes and invokes these methods on logout to ensure sensitive data is cleared. Also added logging for profile loading and error handling in ProfileViewModel.