### PR TITLE
Update layout for EventCard

### DIFF
--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/component/EventCard.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/component/EventCard.kt
@@ -3,7 +3,6 @@ package com.example.mobilecomputingassignment.presentation.ui.component
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.ui.draw.alpha
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,12 +18,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Phone
-import androidx.compose.material.icons.filled.Place
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
@@ -46,6 +42,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -57,71 +54,74 @@ import java.util.Locale
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EventCard(
-        event: Event,
-        isHosted: Boolean = false,
-        onToggleInterest: (() -> Unit)? = null,
-        onCheckIn: (() -> Unit)? = null,
-        onGetDirections: (() -> Unit)? = null,
-        onEditEvent: (() -> Unit)? = null,
-        onDeleteEvent: (() -> Unit)? = null,
-        modifier: Modifier = Modifier
+    event: Event,
+    isHosted: Boolean = false,
+    onToggleInterest: (() -> Unit)? = null,
+    onCheckIn: (() -> Unit)? = null,
+    onGetDirections: (() -> Unit)? = null,
+    onEditEvent: (() -> Unit)? = null,
+    onDeleteEvent: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
 ) {
     var showDeleteDialog by remember { mutableStateOf(false) }
-    
+
     // Check if event is in the past for opacity styling
     val isEventInPast = EventDateUtils.isEventInPast(event)
     val cardAlpha = if (isEventInPast) 0.33f else 1.0f
 
+    // Separate the "- [Event Venue]" from event.title (since it repeats in event.description)
+    val cleanTitle = event.title.split("-").first().trim().replace(" vs ", " vs \n")
+
     Card(
-            modifier = modifier
-                .fillMaxWidth()
-                .alpha(cardAlpha),
-            shape = RoundedCornerShape(20.dp),
-            border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
-            colors =
-                    CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.surface,
-                            contentColor = MaterialTheme.colorScheme.onSurface
-                    )
+        modifier = modifier
+            .fillMaxWidth()
+            .alpha(cardAlpha),
+        shape = RoundedCornerShape(20.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+                contentColor = MaterialTheme.colorScheme.onSurface
+            )
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
-            // Header with gradient background
             Box(
-                    modifier =
-                            Modifier.fillMaxWidth()
-                                    .background(
-                                            color =
-                                                    MaterialTheme.colorScheme.primaryContainer.copy(
-                                                            alpha = 0.3f
-                                                    ),
-                                            shape = RoundedCornerShape(12.dp)
-                                    )
-                                    .padding(16.dp)
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .background(
+                            color =
+                                MaterialTheme.colorScheme.primaryContainer.copy(
+                                    alpha = 0.3f
+                                ),
+                            shape = RoundedCornerShape(12.dp)
+                        )
+                        .padding(16.dp)
             ) {
                 Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.Top
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Top
                 ) {
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
-                                text = event.title,
-                                style = MaterialTheme.typography.titleLarge,
-                                fontWeight = FontWeight.ExtraBold,
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis,
-                                color = MaterialTheme.colorScheme.primary
+                            text = cleanTitle,
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.ExtraBold,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                            color = MaterialTheme.colorScheme.primary
                         )
 
                         if (event.description.isNotBlank()) {
                             Spacer(modifier = Modifier.height(6.dp))
                             Text(
-                                    text = event.description,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-                                    maxLines = 2,
-                                    overflow = TextOverflow.Ellipsis,
-                                    fontWeight = FontWeight.Medium
+                                text = event.description,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                                fontWeight = FontWeight.Medium
                             )
                         }
                     }
@@ -131,66 +131,68 @@ fun EventCard(
                         if (isHosted) {
                             // Edit button with circular background
                             Box(
-                                    modifier =
-                                            Modifier.size(40.dp)
-                                                    .background(
-                                                            MaterialTheme.colorScheme
-                                                                    .primaryContainer,
-                                                            CircleShape
-                                                    ),
-                                    contentAlignment = Alignment.Center
+                                modifier =
+                                    Modifier
+                                        .size(40.dp)
+                                        .background(
+                                            MaterialTheme.colorScheme
+                                                .primaryContainer,
+                                            CircleShape
+                                        ),
+                                contentAlignment = Alignment.Center
                             ) {
                                 IconButton(onClick = { onEditEvent?.invoke() }) {
                                     Icon(
-                                            imageVector = Icons.Default.Edit,
-                                            contentDescription = "Edit Event",
-                                            tint = MaterialTheme.colorScheme.primary,
-                                            modifier = Modifier.size(20.dp)
+                                        imageVector = Icons.Default.Edit,
+                                        contentDescription = "Edit Event",
+                                        tint = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.size(20.dp)
                                     )
                                 }
                             }
 
                             // Delete button with circular background
                             Box(
-                                    modifier =
-                                            Modifier.size(40.dp)
-                                                    .background(
-                                                            MaterialTheme.colorScheme
-                                                                    .errorContainer,
-                                                            CircleShape
-                                                    ),
-                                    contentAlignment = Alignment.Center
+                                modifier =
+                                    Modifier
+                                        .size(40.dp)
+                                        .background(
+                                            MaterialTheme.colorScheme
+                                                .errorContainer,
+                                            CircleShape
+                                        ),
+                                contentAlignment = Alignment.Center
                             ) {
                                 IconButton(onClick = { showDeleteDialog = true }) {
                                     Icon(
-                                            imageVector = Icons.Default.Delete,
-                                            contentDescription = "Delete Event",
-                                            tint = MaterialTheme.colorScheme.error,
-                                            modifier = Modifier.size(20.dp)
+                                        imageVector = Icons.Default.Delete,
+                                        contentDescription = "Delete Event",
+                                        tint = MaterialTheme.colorScheme.error,
+                                        modifier = Modifier.size(20.dp)
                                     )
                                 }
                             }
-                        } else {
-                            // Interest button with circular background
-                            Box(
-                                    modifier =
-                                            Modifier.size(40.dp)
-                                                    .background(
-                                                            MaterialTheme.colorScheme
-                                                                    .tertiaryContainer,
-                                                            CircleShape
-                                                    ),
-                                    contentAlignment = Alignment.Center
-                            ) {
-                                IconButton(onClick = { onToggleInterest?.invoke() }) {
-                                    Icon(
-                                            imageVector = Icons.Default.Favorite,
-                                            contentDescription = "Toggle Interest",
-                                            tint = MaterialTheme.colorScheme.tertiary,
-                                            modifier = Modifier.size(20.dp)
-                                    )
-                                }
-                            }
+//                        } else {
+//                            // Interest button with circular background [REMOVED FOR NOW]
+//                            Box(
+//                                    modifier =
+//                                            Modifier.size(40.dp)
+//                                                    .background(
+//                                                            MaterialTheme.colorScheme
+//                                                                    .tertiaryContainer,
+//                                                            CircleShape
+//                                                    ),
+//                                    contentAlignment = Alignment.Center
+//                            ) {
+//                                IconButton(onClick = { onToggleInterest?.invoke() }) {
+//                                    Icon(
+//                                            imageVector = Icons.Default.Favorite,
+//                                            contentDescription = "Toggle Interest",
+//                                            tint = MaterialTheme.colorScheme.tertiary,
+//                                            modifier = Modifier.size(20.dp)
+//                                    )
+//                                }
+//                            }
                         }
                     }
                 }
@@ -198,59 +200,91 @@ fun EventCard(
 
             Spacer(modifier = Modifier.height(12.dp))
 
+            // Team logos before event details
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TeamLogo(
+                    teamName = event.matchDetails?.homeTeam ?: "TBD",
+                    modifier = Modifier.size(64.dp)
+                )
+
+                Spacer(modifier = Modifier.width(12.dp))
+
+                Text(
+                    text = "vs",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                Spacer(modifier = Modifier.width(12.dp))
+
+                TeamLogo(
+                    teamName = event.matchDetails?.awayTeam ?: "TBD",
+                    modifier = Modifier.size(64.dp)
+                )
+            }
+
             // Event details in nested card
             Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors =
-                            CardDefaults.cardColors(
-                                    containerColor =
-                                            MaterialTheme.colorScheme.surfaceVariant.copy(
-                                                    alpha = 0.3f
-                                            )
-                            ),
-                    shape = RoundedCornerShape(12.dp)
+                modifier = Modifier.fillMaxWidth(),
+                colors =
+                    CardDefaults.cardColors(
+                        containerColor =
+                            MaterialTheme.colorScheme.surfaceVariant.copy(
+                                alpha = 0.3f
+                            )
+                    ),
+                shape = RoundedCornerShape(12.dp)
             ) {
                 Column(modifier = Modifier.padding(16.dp)) {
-                    EventDetailRow(
-                            icon = Icons.Default.DateRange,
-                            label = "Date",
-                            value =
-                                    SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
-                                            .format(event.date)
-                    )
-
-                    EventDetailRow(
-                            icon = Icons.Default.Info,
-                            label = "Check-in",
-                            value =
-                                    SimpleDateFormat("HH:mm", Locale.getDefault())
-                                            .format(event.checkInTime)
-                    )
-
-                    EventDetailRow(
-                            icon = Icons.Default.LocationOn,
-                            label = "Location",
-                            value = event.location.name
+                    // Changing "Location" to text instead, with title size and bold applied
+                    Text(
+                        text = event.location.name,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(vertical = 4.dp)
                     )
 
                     if (event.location.address.isNotBlank()) {
-                        EventDetailRow(
-                                icon = Icons.Default.Place,
-                                label = "Address",
-                                value = event.location.address
+                        Text(
+                            text = event.location.address,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                            modifier = Modifier.padding(bottom = 8.dp)
                         )
                     }
 
                     EventDetailRow(
-                            icon = Icons.Default.Person,
-                            label = "Capacity",
-                            value = "${event.attendeesCount}/${event.capacity}"
+                        icon = Icons.Default.DateRange,
+                        label = "Date",
+                        value =
+                            SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+                                .format(event.date)
+                    )
+
+                    EventDetailRow(
+                        icon = Icons.Default.Info,
+                        label = "Check-in",
+                        value =
+                            SimpleDateFormat("HH:mm", Locale.getDefault())
+                                .format(event.checkInTime)
+                    )
+
+                    EventDetailRow(
+                        icon = Icons.Default.Person,
+                        label = "Capacity",
+                        value = "${event.attendeesCount}/${event.capacity}"
                     )
                     if (event.contactNumber.isNotBlank()) {
                         EventDetailRow(
-                                icon = Icons.Default.Phone,
-                                label = "Contact",
-                                value = event.contactNumber
+                            icon = Icons.Default.Phone,
+                            label = "Contact",
+                            value = event.contactNumber
                         )
                     }
                 }
@@ -258,16 +292,16 @@ fun EventCard(
 
             // Amenities and accessibility indicators
             if (event.amenities.isIndoor ||
-                            event.amenities.isOutdoor ||
-                            event.amenities.isChildFriendly ||
-                            event.amenities.isPetFriendly
+                event.amenities.isOutdoor ||
+                event.amenities.isChildFriendly ||
+                event.amenities.isPetFriendly
             ) {
 
                 Spacer(modifier = Modifier.height(8.dp))
 
                 Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        modifier = Modifier.fillMaxWidth()
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth()
                 ) {
                     if (event.amenities.isIndoor) {
                         AmenityChip("Indoor")
@@ -289,17 +323,17 @@ fun EventCard(
                 Spacer(modifier = Modifier.height(12.dp))
 
                 Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     OutlinedButton(
-                            onClick = { onToggleInterest?.invoke() },
-                            modifier = Modifier.weight(1f)
+                        onClick = { onToggleInterest?.invoke() },
+                        modifier = Modifier.weight(1f)
                     ) { Text("Uninterest") }
 
                     Button(
-                            onClick = { onGetDirections?.invoke() ?: onCheckIn?.invoke() },
-                            modifier = Modifier.weight(1f)
+                        onClick = { onGetDirections?.invoke() ?: onCheckIn?.invoke() },
+                        modifier = Modifier.weight(1f)
                     ) { Text(if (onGetDirections != null) "Directions" else "Check In") }
                 }
             }
@@ -309,67 +343,70 @@ fun EventCard(
     // Delete confirmation dialog
     if (showDeleteDialog) {
         AlertDialog(
-                onDismissRequest = { showDeleteDialog = false },
-                title = { Text("Delete Event") },
-                text = {
-                    Text(
-                            "Are you sure you want to delete this event? This action cannot be undone."
-                    )
-                },
-                confirmButton = {
-                    Button(
-                            onClick = {
-                                showDeleteDialog = false
-                                onDeleteEvent?.invoke()
-                            },
-                            colors =
-                                    ButtonDefaults.buttonColors(
-                                            containerColor = MaterialTheme.colorScheme.error
-                                    )
-                    ) { Text("Delete") }
-                },
-                dismissButton = {
-                    TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel") }
-                }
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("Delete Event") },
+            text = {
+                Text(
+                    "Are you sure you want to delete this event? This action cannot be undone."
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showDeleteDialog = false
+                        onDeleteEvent?.invoke()
+                    },
+                    colors =
+                        ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error
+                        )
+                ) { Text("Delete") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel") }
+            }
         )
     }
 }
 
 @Composable
 private fun EventDetailRow(
-        icon: androidx.compose.ui.graphics.vector.ImageVector,
-        label: String,
-        value: String,
-        modifier: Modifier = Modifier
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier
 ) {
     Row(
-            modifier = modifier.fillMaxWidth().padding(vertical = 2.dp),
-            verticalAlignment = Alignment.CenterVertically
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
         Box(
-                modifier =
-                        Modifier.size(32.dp)
-                                .background(
-                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
-                                        CircleShape
-                                ),
-                contentAlignment = Alignment.Center
+            modifier =
+                Modifier
+                    .size(32.dp)
+                    .background(
+                        MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
+                        CircleShape
+                    ),
+            contentAlignment = Alignment.Center
         ) {
             Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
-                    tint = MaterialTheme.colorScheme.primary
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.primary
             )
         }
 
         Spacer(modifier = Modifier.width(12.dp))
 
         Text(
-                text = value,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                fontWeight = FontWeight.Medium
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Medium
         )
     }
 }
@@ -377,13 +414,13 @@ private fun EventDetailRow(
 @Composable
 private fun AmenityChip(text: String, modifier: Modifier = Modifier) {
     AssistChip(
-            onClick = {},
-            label = { Text(text = text, style = MaterialTheme.typography.labelSmall) },
-            modifier = modifier,
-            colors =
-                    AssistChipDefaults.assistChipColors(
-                            containerColor = MaterialTheme.colorScheme.primaryContainer,
-                            labelColor = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
+        onClick = {},
+        label = { Text(text = text, style = MaterialTheme.typography.labelSmall) },
+        modifier = modifier,
+        colors =
+            AssistChipDefaults.assistChipColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                labelColor = MaterialTheme.colorScheme.onPrimaryContainer
+            )
     )
 }

--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/component/TeamLogo.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/component/TeamLogo.kt
@@ -1,8 +1,13 @@
 package com.example.mobilecomputingassignment.presentation.ui.component
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -12,20 +17,22 @@ import com.example.mobilecomputingassignment.R
 import com.example.mobilecomputingassignment.data.utils.TeamLogoMapper
 
 @Composable
-fun TeamLogo(teamName: String) {
-  Card(
-          modifier = Modifier.size(40.dp),
-          colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
-  ) {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-      Image(
-              painter =
-                      painterResource(
-                              TeamLogoMapper.getTeamLogoByName(teamName) ?: R.drawable.ic_sports
-                      ),
-              contentDescription = "$teamName logo",
-              modifier = Modifier.fillMaxSize().padding(4.dp)
-      )
+fun TeamLogo(teamName: String, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.size(40.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Image(
+                painter =
+                    painterResource(
+                        TeamLogoMapper.getTeamLogoByName(teamName) ?: R.drawable.ic_sports
+                    ),
+                contentDescription = "$teamName logo",
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(4.dp)
+            )
+        }
     }
-  }
 }

--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/screen/TeamSelectionScreen.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/screen/TeamSelectionScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -42,7 +43,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.example.mobilecomputingassignment.domain.models.Team
-import androidx.compose.foundation.layout.statusBarsPadding
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -67,7 +67,7 @@ fun TeamSelectionScreen(
                         Icon(Icons.Default.ArrowBack, contentDescription = "Back")
                     }
                 },
-                modifier = Modifier.statusBarsPadding() // ADD THIS LINE
+                modifier = Modifier.statusBarsPadding()
             )
         },
             bottomBar = {
@@ -81,9 +81,7 @@ fun TeamSelectionScreen(
         Box(modifier = Modifier.padding(paddingValues).fillMaxSize()) {
             if (isLoading) {
                 Box(
-                        modifier = Modifier.fillMaxSize(), // Changed from
-                        // fillMaxWidth().height(320.dp) to fill
-                        // screen
+                        modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center
                 ) { CircularProgressIndicator() }
             } else if (availableTeams.isEmpty()) {
@@ -98,10 +96,7 @@ fun TeamSelectionScreen(
             } else {
                 LazyColumn(
                         verticalArrangement =
-                                Arrangement.spacedBy(8.dp), // Matched from SignupTeamStep
-                        // If you want the fixed height like SignupTeamStep:
-                        // modifier = Modifier.height(320.dp).padding(horizontal = 16.dp)
-                        // If you want it to fill available space in Scaffold:
+                                Arrangement.spacedBy(8.dp),
                         modifier =
                                 Modifier.fillMaxSize().padding(horizontal = 16.dp, vertical = 8.dp)
                 ) {


### PR DESCRIPTION
- EventCard:
    - Display team logos above event details.
    - Clean event title by removing venue information (already present in description).
    - Format match title "Team A vs Team B" to be on two lines for better readability.
    - Change "Location" display from an icon-based row to bold H5 text.
    - Temporarily disabled the "Toggle Interest" button; not sure if needed later
- TeamSelectionScreen:
    - Remove commented-out code and simplify loading/empty state layout.
- TeamLogo:
    - Add optional modifier parameter for better composability.