### PR TITLE
Update NearbyMatchCard and MatchDetailDrawer to match aesthetic of EventCard

### DIFF
--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/screens/explore/components/MatchDetailDrawer.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/screens/explore/components/MatchDetailDrawer.kt
@@ -2,8 +2,22 @@ package com.example.mobilecomputingassignment.presentation.screens.explore.compo
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -12,8 +26,20 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -21,115 +47,125 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import com.example.mobilecomputingassignment.R
 import com.example.mobilecomputingassignment.domain.models.Event
 import com.example.mobilecomputingassignment.presentation.ui.component.TeamLogo
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Date
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MatchDetailDrawer(
-        event: Event,
-        isVisible: Boolean,
-        onDismiss: () -> Unit,
-        onGetDirections: (Event) -> Unit,
-        onToggleInterest: (Event) -> Unit,
-        currentUserId: String? = null,
-        isUpdatingInterest: Boolean = false,
-        modifier: Modifier = Modifier
+    event: Event,
+    isVisible: Boolean,
+    onDismiss: () -> Unit,
+    onGetDirections: (Event) -> Unit,
+    onToggleInterest: (Event) -> Unit,
+    currentUserId: String? = null,
+    isUpdatingInterest: Boolean = false,
+    modifier: Modifier = Modifier
 ) {
     // Animation for drawer visibility
     val animatedAlpha by
-            animateFloatAsState(
-                    targetValue = if (isVisible) 1f else 0f,
-                    animationSpec = tween(durationMillis = 300),
-                    label = "drawer_alpha"
-            )
+    animateFloatAsState(
+        targetValue = if (isVisible) 1f else 0f,
+        animationSpec = tween(durationMillis = 300),
+        label = "drawer_alpha"
+    )
 
     val animatedOffset by
-            animateFloatAsState(
-                    targetValue = if (isVisible) 0f else 1f,
-                    animationSpec = tween(durationMillis = 300),
-                    label = "drawer_offset"
-            )
+    animateFloatAsState(
+        targetValue = if (isVisible) 0f else 1f,
+        animationSpec = tween(durationMillis = 300),
+        label = "drawer_offset"
+    )
 
     if (isVisible) {
         Box(
-                modifier =
-                        modifier.fillMaxSize()
-                                .zIndex(10f) // Higher z-index than the nearest events drawer
+            modifier =
+                modifier
+                    .fillMaxSize()
+                    .zIndex(10f) // Higher z-index than the nearest events drawer
         ) {
             // Background overlay
             Box(
-                    modifier =
-                            Modifier.fillMaxSize()
-                                    .background(Color.Black.copy(alpha = animatedAlpha * 0.3f))
-                                    .zIndex(1f)
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(Color.Black.copy(alpha = animatedAlpha * 0.3f))
+                        .zIndex(1f)
             )
 
             // Drawer content
             Column(
-                    modifier =
-                            Modifier.align(Alignment.BottomCenter)
-                                    .fillMaxWidth()
-                                    .heightIn(min = 400.dp, max = 700.dp)
-                                    .shadow(
-                                            elevation = 16.dp,
-                                            shape =
-                                                    RoundedCornerShape(
-                                                            topStart = 24.dp,
-                                                            topEnd = 24.dp
-                                                    )
-                                    )
-                                    .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
-                                    .background(Color.White)
-                                    .zIndex(2f)
-                                    .offset(y = (animatedOffset * 100).dp)
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .heightIn(min = 400.dp, max = 700.dp)
+                        .shadow(
+                            elevation = 16.dp,
+                            shape =
+                                RoundedCornerShape(
+                                    topStart = 24.dp,
+                                    topEnd = 24.dp
+                                )
+                        )
+                        .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+                        .background(Color.White)
+                        .zIndex(2f)
+                        .offset(y = (animatedOffset * 100).dp)
             ) {
                 // Header with close button
                 Row(
-                        modifier = Modifier.fillMaxWidth().padding(16.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                            text = "Match Details",
-                            style = MaterialTheme.typography.headlineSmall,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface
+                        text = "Match Details",
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface
                     )
 
                     IconButton(
-                            onClick = onDismiss,
-                            modifier =
-                                    Modifier.background(
-                                                    MaterialTheme.colorScheme.surfaceVariant,
-                                                    CircleShape
-                                            )
-                                            .size(32.dp)
+                        onClick = onDismiss,
+                        modifier =
+                            Modifier
+                                .background(
+                                    MaterialTheme.colorScheme.surfaceVariant,
+                                    CircleShape
+                                )
+                                .size(32.dp)
                     ) {
                         Icon(
-                                imageVector = Icons.Default.Close,
-                                contentDescription = "Close",
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.size(20.dp)
+                            imageVector = Icons.Default.Close,
+                            contentDescription = "Close",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(20.dp)
                         )
                     }
                 }
 
                 HorizontalDivider(
-                        color = MaterialTheme.colorScheme.surfaceVariant,
-                        thickness = 1.dp
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                    thickness = 1.dp
                 )
 
                 // Scrollable content
                 LazyColumn(
-                        modifier = Modifier.fillMaxWidth().weight(1f),
-                        contentPadding = PaddingValues(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     // Teams section
                     item { TeamsSection(event = event) }
@@ -137,14 +173,11 @@ fun MatchDetailDrawer(
                     // Date and time section
                     item { DateTimeSection(event = event) }
 
+                    // Event description section
+                    item { DescriptionSection(event = event) }
+
                     // Venue section
                     item { VenueSection(event = event) }
-
-                    // Amenities section
-                    item { AmenitiesSection(event = event) }
-
-                    // Accessibility section
-                    item { AccessibilitySection(event = event) }
 
                     // Host information section
                     item { HostSection(event = event) }
@@ -152,11 +185,14 @@ fun MatchDetailDrawer(
                     // Capacity and attendees section
                     item { CapacitySection(event = event) }
 
+                    // Amenities section
+                    item { AmenitiesSection(event = event) }
+
+                    // Accessibility section
+                    item { AccessibilitySection(event = event) }
+
                     // Contact information section
                     item { ContactSection(event = event) }
-
-                    // Event description section
-                    item { DescriptionSection(event = event) }
 
                     // Interest count section
                     item { InterestCountSection(event = event) }
@@ -167,27 +203,11 @@ fun MatchDetailDrawer(
 
                 // Action buttons
                 Row(
-                        modifier = Modifier.fillMaxWidth().padding(16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
-                    // Directions button
-                    Button(
-                            onClick = { onGetDirections(event) },
-                            modifier = Modifier.weight(1f),
-                            colors =
-                                    ButtonDefaults.buttonColors(
-                                            containerColor = MaterialTheme.colorScheme.primary
-                                    )
-                    ) {
-                        Icon(
-                                painter = painterResource(id = R.drawable.ic_direction),
-                                contentDescription = "Get directions",
-                                modifier = Modifier.size(18.dp)
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text("Directions")
-                    }
-
                     // Interest button
                     val isInterested = event.interestedUsers.contains(currentUserId)
                     val canInterest = currentUserId != null && currentUserId != event.hostUserId
@@ -196,58 +216,76 @@ fun MatchDetailDrawer(
                     android.util.Log.d("MatchDetailDrawer", "Interest button debug:")
                     android.util.Log.d("MatchDetailDrawer", "  currentUserId: $currentUserId")
                     android.util.Log.d(
-                            "MatchDetailDrawer",
-                            "  event.hostUserId: ${event.hostUserId}"
+                        "MatchDetailDrawer",
+                        "  event.hostUserId: ${event.hostUserId}"
                     )
                     android.util.Log.d("MatchDetailDrawer", "  canInterest: $canInterest")
                     android.util.Log.d("MatchDetailDrawer", "  isInterested: $isInterested")
 
                     OutlinedButton(
-                            onClick = {
-                                if (canInterest && !isUpdatingInterest) {
-                                    android.util.Log.d(
-                                            "MatchDetailDrawer",
-                                            "Interest button clicked"
-                                    )
-                                    onToggleInterest(event)
-                                }
-                            },
-                            modifier = Modifier.weight(1f),
-                            enabled = canInterest && !isUpdatingInterest,
-                            colors =
-                                    ButtonDefaults.outlinedButtonColors(
-                                            contentColor =
-                                                    if (isInterested) {
-                                                        MaterialTheme.colorScheme.error
-                                                    } else {
-                                                        MaterialTheme.colorScheme.primary
-                                                    }
-                                    )
+                        onClick = {
+                            if (canInterest && !isUpdatingInterest) {
+                                android.util.Log.d(
+                                    "MatchDetailDrawer",
+                                    "Interest button clicked"
+                                )
+                                onToggleInterest(event)
+                            }
+                        },
+                        modifier = Modifier.weight(1f),
+                        enabled = canInterest && !isUpdatingInterest,
+                        colors =
+                            ButtonDefaults.outlinedButtonColors(
+                                contentColor =
+                                    if (isInterested) {
+                                        MaterialTheme.colorScheme.error
+                                    } else {
+                                        MaterialTheme.colorScheme.primary
+                                    }
+                            )
                     ) {
                         if (isUpdatingInterest) {
                             CircularProgressIndicator(
-                                    modifier = Modifier.size(18.dp),
-                                    strokeWidth = 2.dp,
-                                    color = MaterialTheme.colorScheme.primary
+                                modifier = Modifier.size(18.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.primary
                             )
                         } else {
                             Icon(
-                                    imageVector =
-                                            if (isInterested) Icons.Default.Favorite
-                                            else Icons.Default.FavoriteBorder,
-                                    contentDescription =
-                                            if (isInterested) "Uninterest" else "Add interest",
-                                    modifier = Modifier.size(18.dp)
+                                imageVector =
+                                    if (isInterested) Icons.Default.Favorite
+                                    else Icons.Default.FavoriteBorder,
+                                contentDescription =
+                                    if (isInterested) "Uninterest" else "Add interest",
+                                modifier = Modifier.size(18.dp)
                             )
                         }
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
-                                when {
-                                    isUpdatingInterest -> "Updating..."
-                                    isInterested -> "Interested"
-                                    else -> "Interest"
-                                }
+                            when {
+                                isUpdatingInterest -> "Updating..."
+                                isInterested -> "Interested"
+                                else -> "Interest"
+                            }
                         )
+                    }
+
+                    // Directions button
+                    Button(
+                        onClick = { onGetDirections(event) },
+                        modifier = Modifier.weight(1f),
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.primary
+                            )
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_direction),
+                            contentDescription = "Get directions",
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Directions")
                     }
                 }
             }
@@ -258,58 +296,67 @@ fun MatchDetailDrawer(
 @Composable
 private fun TeamsSection(event: Event) {
     Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors =
-                    CardDefaults.cardColors(
-                            containerColor =
-                                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
-                    ),
-            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors =
+            CardDefaults.cardColors(
+                containerColor =
+                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+            ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
         Column(
-                modifier = Modifier.fillMaxWidth().padding(16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text(
-                    text = "Match",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface
-            )
 
             Spacer(modifier = Modifier.height(16.dp))
 
             Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceEvenly,
-                    verticalAlignment = Alignment.CenterVertically
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 // Home team
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    TeamLogo(teamName = event.matchDetails?.homeTeam ?: "TBD")
+                Column(horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.weight(1f)) {
+                    TeamLogo(
+                        teamName = event.matchDetails?.homeTeam ?: "TBD",
+                        modifier = Modifier.size(64.dp)
+                    )
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
-                            text = event.matchDetails?.homeTeam ?: "TBD",
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Medium
+                        text = event.matchDetails?.homeTeam ?: "TBD",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        modifier = Modifier.fillMaxWidth(),
+                        textAlign = TextAlign.Center
                     )
                 }
 
                 Text(
-                        text = "VS",
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.primary
+                    text = "VS",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(horizontal = 8.dp)
                 )
 
                 // Away team
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    TeamLogo(teamName = event.matchDetails?.awayTeam ?: "TBD")
+                Column(horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.weight(1f)) {
+                    TeamLogo(
+                        teamName = event.matchDetails?.awayTeam ?: "TBD",
+                        modifier = Modifier.size(64.dp)
+                    )
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
-                            text = event.matchDetails?.awayTeam ?: "TBD",
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Medium
+                        text = event.matchDetails?.awayTeam ?: "TBD",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        modifier = Modifier.fillMaxWidth(),
+                        textAlign = TextAlign.Center
                     )
                 }
             }
@@ -320,48 +367,52 @@ private fun TeamsSection(event: Event) {
 @Composable
 private fun DateTimeSection(event: Event) {
     Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
         Row(
-                modifier = Modifier.fillMaxWidth().padding(16.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
         ) {
             // Date
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(
-                        painter = painterResource(id = R.drawable.ic_calendar),
-                        contentDescription = "Date",
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(20.dp)
+                    painter = painterResource(id = R.drawable.ic_calendar),
+                    contentDescription = "Date",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp)
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                        text =
-                                SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
-                                        .format(event.date),
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Medium
+                    text =
+                        SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
+                            .format(event.date),
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium
                 )
             }
 
             // Time
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(
-                        painter = painterResource(id = R.drawable.ic_clock),
-                        contentDescription = "Time",
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(20.dp)
+                    painter = painterResource(id = R.drawable.ic_clock),
+                    contentDescription = "Time",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp)
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                        text =
-                                SimpleDateFormat("HH:mm", Locale.getDefault())
-                                        .format(event.checkInTime),
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Medium
+                    text =
+                        SimpleDateFormat("HH:mm", Locale.getDefault())
+                            .format(event.checkInTime),
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium
                 )
             }
         }
@@ -371,48 +422,54 @@ private fun DateTimeSection(event: Event) {
 @Composable
 private fun VenueSection(event: Event) {
     Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
-        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(
-                        painter = painterResource(id = R.drawable.ic_location),
-                        contentDescription = "Location",
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(20.dp)
+                    painter = painterResource(id = R.drawable.ic_location),
+                    contentDescription = "Location",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp)
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                        text = "Venue",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
+                    text = "Venue",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
                 )
             }
 
             Spacer(modifier = Modifier.height(8.dp))
 
             Text(
-                    text = event.location.name,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium
+                text = event.location.name,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium
             )
 
             Text(
-                    text = event.location.address,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                text = event.location.address,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
 
             if (event.contactNumber.isNotBlank()) {
                 Spacer(modifier = Modifier.height(8.dp))
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
-                            painter = painterResource(id = R.drawable.ic_phone),
-                            contentDescription = "Contact",
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(16.dp)
+                        painter = painterResource(id = R.drawable.ic_phone),
+                        contentDescription = "Contact",
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(16.dp)
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(text = event.contactNumber, style = MaterialTheme.typography.bodyMedium)
@@ -425,30 +482,36 @@ private fun VenueSection(event: Event) {
 @Composable
 private fun AmenitiesSection(event: Event) {
     val amenities =
-            listOf(
-                            "Indoor" to event.amenities.isIndoor,
-                            "Outdoor" to event.amenities.isOutdoor,
-                            "Child Friendly" to event.amenities.isChildFriendly,
-                            "Pet Friendly" to event.amenities.isPetFriendly,
-                            "Parking" to event.amenities.hasParking,
-                            "Food" to event.amenities.hasFood,
-                            "Toilet" to event.amenities.hasToilet,
-                            "WiFi" to event.amenities.hasWifi
-                    )
-                    .filter { it.second }
+        listOf(
+            "Indoor" to event.amenities.isIndoor,
+            "Outdoor" to event.amenities.isOutdoor,
+            "Child Friendly" to event.amenities.isChildFriendly,
+            "Pet Friendly" to event.amenities.isPetFriendly,
+            "Parking" to event.amenities.hasParking,
+            "Food" to event.amenities.hasFood,
+            "Toilet" to event.amenities.hasToilet,
+            "WiFi" to event.amenities.hasWifi
+        )
+            .filter { it.second }
 
     if (amenities.isNotEmpty()) {
         Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors =
-                        CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
+            colors =
+                CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
         ) {
-            Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
                 Text(
-                        text = "Amenities",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
+                    text = "Amenities",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -457,10 +520,10 @@ private fun AmenitiesSection(event: Event) {
                     items(amenities) { (amenity, _) ->
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Icon(
-                                    imageVector = Icons.Default.Favorite,
-                                    contentDescription = amenity,
-                                    tint = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier.size(16.dp)
+                                imageVector = Icons.Default.Favorite,
+                                contentDescription = amenity,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(16.dp)
                             )
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(text = amenity, style = MaterialTheme.typography.bodyMedium)
@@ -475,27 +538,33 @@ private fun AmenitiesSection(event: Event) {
 @Composable
 private fun AccessibilitySection(event: Event) {
     val accessibility =
-            listOf(
-                            "Wheelchair Accessible" to event.accessibility.isWheelchairAccessible,
-                            "Accessible Toilets" to event.accessibility.hasAccessibleToilets,
-                            "Accessible Parking" to event.accessibility.hasAccessibleParking,
-                            "Sign Language Support" to event.accessibility.hasSignLanguageSupport,
-                            "Audio Support" to event.accessibility.hasAudioSupport
-                    )
-                    .filter { it.second }
+        listOf(
+            "Wheelchair Accessible" to event.accessibility.isWheelchairAccessible,
+            "Accessible Toilets" to event.accessibility.hasAccessibleToilets,
+            "Accessible Parking" to event.accessibility.hasAccessibleParking,
+            "Sign Language Support" to event.accessibility.hasSignLanguageSupport,
+            "Audio Support" to event.accessibility.hasAudioSupport
+        )
+            .filter { it.second }
 
     if (accessibility.isNotEmpty()) {
         Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors =
-                        CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
+            colors =
+                CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
         ) {
-            Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
                 Text(
-                        text = "Accessibility",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
+                    text = "Accessibility",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -504,10 +573,10 @@ private fun AccessibilitySection(event: Event) {
                     items(accessibility) { (feature, _) ->
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Icon(
-                                    painter = painterResource(id = R.drawable.ic_accessible),
-                                    contentDescription = feature,
-                                    tint = MaterialTheme.colorScheme.primary,
-                                    modifier = Modifier.size(16.dp)
+                                painter = painterResource(id = R.drawable.ic_accessible),
+                                contentDescription = feature,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(16.dp)
                             )
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(text = feature, style = MaterialTheme.typography.bodyMedium)
@@ -522,31 +591,34 @@ private fun AccessibilitySection(event: Event) {
 @Composable
 private fun InterestCountSection(event: Event) {
     Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors =
-                    CardDefaults.cardColors(
-                            containerColor =
-                                    MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
-                    ),
-            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors =
+            CardDefaults.cardColors(
+                containerColor =
+                    MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
+            ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
         Row(
-                modifier = Modifier.fillMaxWidth().padding(16.dp),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
-                    imageVector = Icons.Default.Favorite,
-                    contentDescription = "Interested users",
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(20.dp)
+                imageVector = Icons.Default.Favorite,
+                contentDescription = "Interested users",
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(20.dp)
             )
             Spacer(modifier = Modifier.width(8.dp))
             Text(
-                    text = "${event.interestedUsers.size} people interested",
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium,
-                    color = MaterialTheme.colorScheme.primary
+                text = "${event.interestedUsers.size} people interested",
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.primary
             )
         }
     }
@@ -564,39 +636,48 @@ private fun NoiseLevelSection(event: Event) {
 
     if (isOngoing && event.recentNoiseDbfs != null) {
         val noiseLevel =
-                com.example.mobilecomputingassignment.domain.models.NoiseLevel.fromDbfs(
-                        event.recentNoiseDbfs
-                )
+            com.example.mobilecomputingassignment.domain.models.NoiseLevel.fromDbfs(
+                event.recentNoiseDbfs
+            )
 
         if (noiseLevel != null) {
             val backgroundColor = Color(noiseLevel.color).copy(alpha = 0.1f)
             val textColor = Color(noiseLevel.color)
 
             Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(containerColor = backgroundColor),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
+                colors = CardDefaults.cardColors(containerColor = backgroundColor),
+                elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
             ) {
                 Row(
-                        modifier = Modifier.fillMaxWidth().padding(16.dp),
-                        horizontalArrangement = Arrangement.Center,
-                        verticalAlignment = Alignment.CenterVertically
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
                     Icon(
-                            painter = painterResource(id = R.drawable.ic_volume),
-                            contentDescription = "Noise level",
-                            tint = textColor,
-                            modifier = Modifier.size(20.dp)
+                        painter = painterResource(id = R.drawable.ic_volume),
+                        contentDescription = "Noise level",
+                        tint = textColor,
+                        modifier = Modifier.size(20.dp)
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                            text =
-                                    "Noise Level: ${noiseLevel.displayName} (${String.format("%.1f", event.recentNoiseDbfs)} dBFS)",
-                            style =
-                                    MaterialTheme.typography.bodyLarge.copy(
-                                            color = textColor,
-                                            fontWeight = FontWeight.Medium
-                                    )
+                        text =
+                            "Noise Level: ${noiseLevel.displayName} (${
+                                String.format(
+                                    "%.1f",
+                                    event.recentNoiseDbfs
+                                )
+                            } dBFS)",
+                        style =
+                            MaterialTheme.typography.bodyLarge.copy(
+                                color = textColor,
+                                fontWeight = FontWeight.Medium
+                            )
                     )
                 }
             }
@@ -607,33 +688,39 @@ private fun NoiseLevelSection(event: Event) {
 @Composable
 private fun HostSection(event: Event) {
     Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
-        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
             Text(
-                    text = "Host Information",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary
+                text = "Host Information",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary
             )
             Spacer(modifier = Modifier.height(8.dp))
             Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(
-                        painter = painterResource(id = R.drawable.ic_groups),
-                        contentDescription = "Host",
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(20.dp)
+                    painter = painterResource(id = R.drawable.ic_groups),
+                    contentDescription = "Host",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp)
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                        text = event.hostUsername.ifEmpty { "Anonymous Host" },
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Medium
+                    text = event.hostUsername.ifEmpty { "Anonymous Host" },
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium
                 )
             }
         }
@@ -643,42 +730,48 @@ private fun HostSection(event: Event) {
 @Composable
 private fun CapacitySection(event: Event) {
     Card(
-            modifier = Modifier.fillMaxWidth(),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
-        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
             Text(
-                    text = "Event Capacity",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary
+                text = "Event Capacity",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary
             )
             Spacer(modifier = Modifier.height(8.dp))
             Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
-                            painter = painterResource(id = R.drawable.ic_groups),
-                            contentDescription = "Attendees",
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(20.dp)
+                        painter = painterResource(id = R.drawable.ic_groups),
+                        contentDescription = "Attendees",
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(20.dp)
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                            text = "${event.attendeesCount} attending",
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.Medium
+                        text = "${event.attendeesCount} attending",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium
                     )
                 }
                 if (event.capacity > 0) {
                     Text(
-                            text = "of ${event.capacity}",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        text = "of ${event.capacity}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
             }
@@ -690,34 +783,40 @@ private fun CapacitySection(event: Event) {
 private fun ContactSection(event: Event) {
     if (event.contactNumber.isNotEmpty()) {
         Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors =
-                        CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
+            colors =
+                CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
         ) {
-            Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
                 Text(
-                        text = "Contact Information",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.primary
+                    text = "Contact Information",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
                     Icon(
-                            painter = painterResource(id = R.drawable.ic_phone),
-                            contentDescription = "Phone",
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(20.dp)
+                        painter = painterResource(id = R.drawable.ic_phone),
+                        contentDescription = "Phone",
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(20.dp)
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                            text = event.contactNumber,
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.Medium
+                        text = event.contactNumber,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium
                     )
                 }
             }
@@ -730,23 +829,29 @@ private fun DescriptionSection(event: Event) {
     val description = event.description
     if (description.isNotEmpty()) {
         Card(
-                modifier = Modifier.fillMaxWidth(),
-                colors =
-                        CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(16.dp),
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
+            colors =
+                CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
         ) {
-            Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
                 Text(
-                        text = "Event Description",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.primary
+                    text = "Event Description",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                        text = description,
-                        style = MaterialTheme.typography.bodyLarge,
-                        lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.2
+                    text = description,
+                    style = MaterialTheme.typography.bodyLarge,
+                    lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.2
                 )
             }
         }

--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/component/NearbyMatchCard.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/component/NearbyMatchCard.kt
@@ -1,8 +1,26 @@
 package com.example.mobilecomputingassignment.presentation.ui.component
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -13,100 +31,107 @@ import androidx.compose.ui.unit.dp
 import com.example.mobilecomputingassignment.R
 import com.example.mobilecomputingassignment.domain.models.Event
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NearbyMatchCard(event: Event, onClick: () -> Unit) {
     Card(
-            onClick = onClick,
-            modifier = Modifier.fillMaxWidth(),
-            colors =
-                    CardDefaults.cardColors(
-                            containerColor = Color.White,
-                            contentColor = MaterialTheme.colorScheme.onSurface
-                    ),
-            border = BorderStroke(width = 0.dp, color = Color.Transparent),
-            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = Color.White,
+                contentColor = MaterialTheme.colorScheme.onSurface
+            ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
-        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
             Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 // Teams Column (Left side)
                 Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
                     // Home Team
                     Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.height(40.dp)
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.height(40.dp)
                     ) {
                         TeamLogo(teamName = event.matchDetails?.homeTeam ?: "TBD")
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
-                                text = event.matchDetails?.homeTeam ?: "TBD",
-                                style = MaterialTheme.typography.bodyLarge,
-                                fontWeight = FontWeight.Bold
+                            text = event.matchDetails?.homeTeam ?: "TBD",
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.Bold
                         )
                     }
 
                     // Away Team
                     Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.height(40.dp)
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.height(40.dp)
                     ) {
                         TeamLogo(teamName = event.matchDetails?.awayTeam ?: "TBD")
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
-                                text = event.matchDetails?.awayTeam ?: "TBD",
-                                style = MaterialTheme.typography.bodyLarge,
-                                fontWeight = FontWeight.Bold
+                            text = event.matchDetails?.awayTeam ?: "TBD",
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.Bold
                         )
                     }
                 }
 
                 // Date and Time Column (Right side)
                 Column(
-                        horizontalAlignment = Alignment.End,
-                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    horizontalAlignment = Alignment.End,
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     // Smart Date Display - Enhanced for today's events
                     val isToday = isEventToday(event.date)
                     Text(
-                            text = getSmartDateText(event.date),
-                            style =
-                                    if (isToday) {
-                                        MaterialTheme.typography.titleMedium
-                                    } else {
-                                        MaterialTheme.typography.bodyMedium
-                                    },
-                            fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
-                            color =
-                                    if (isToday) {
-                                        MaterialTheme.colorScheme.primary
-                                    } else {
-                                        MaterialTheme.colorScheme.onSurfaceVariant
-                                    }
+                        text = getSmartDateText(event.date),
+                        style =
+                            if (isToday) {
+                                MaterialTheme.typography.titleMedium
+                            } else {
+                                MaterialTheme.typography.bodyMedium
+                            },
+                        fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
+                        color =
+                            if (isToday) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            }
                     )
 
                     // Time - Enhanced for today's events
                     Text(
-                            text =
-                                    SimpleDateFormat("HH:mm", Locale.getDefault())
-                                            .format(event.checkInTime),
-                            style =
-                                    if (isToday) {
-                                        MaterialTheme.typography.titleMedium
-                                    } else {
-                                        MaterialTheme.typography.bodyMedium
-                                    },
-                            fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
-                            color =
-                                    if (isToday) {
-                                        MaterialTheme.colorScheme.primary
-                                    } else {
-                                        MaterialTheme.colorScheme.primary
-                                    }
+                        text =
+                            SimpleDateFormat("HH:mm", Locale.getDefault())
+                                .format(event.checkInTime),
+                        style =
+                            if (isToday) {
+                                MaterialTheme.typography.titleMedium
+                            } else {
+                                MaterialTheme.typography.bodyMedium
+                            },
+                        fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
+                        color =
+                            if (isToday) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.primary
+                            }
                     )
                 }
             }
@@ -115,36 +140,48 @@ fun NearbyMatchCard(event: Event, onClick: () -> Unit) {
 
             // Venue
             Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .background(
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
+                            CircleShape
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
                         painter = painterResource(id = R.drawable.ic_location),
                         contentDescription = "Location",
                         tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.size(16.dp)
-                )
-                Spacer(modifier = Modifier.width(4.dp))
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(16.dp))
+
                 Column {
                     Text(
-                            text = event.location.name,
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Medium
+                        text = event.location.name,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium
                     )
                     Text(
-                            text = event.location.address,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        text = event.location.address,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
 
                 if (event.accessibility.isWheelchairAccessible) {
                     Spacer(modifier = Modifier.weight(1f))
                     Icon(
-                            painter = painterResource(id = R.drawable.ic_accessible),
-                            contentDescription = "Wheelchair accessible",
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(20.dp)
+                        painter = painterResource(id = R.drawable.ic_accessible),
+                        contentDescription = "Wheelchair accessible",
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(20.dp)
                     )
                 }
             }
@@ -152,9 +189,9 @@ fun NearbyMatchCard(event: Event, onClick: () -> Unit) {
 
         // Bottom Divider
         HorizontalDivider(
-                color = MaterialTheme.colorScheme.surfaceVariant,
-                thickness = 1.dp,
-                modifier = Modifier.fillMaxWidth()
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            thickness = 1.dp,
+            modifier = Modifier.fillMaxWidth()
         )
     }
 }


### PR DESCRIPTION
Updated NearbyMatchCard and MatchDetailDrawer cards to match the same aesthetic as EventCard, ensuring consistency between them. Changes made include their shape, logo sizing, color, order of sections, and positions of interest + directions buttons.

<img width="1080" height="2400" alt="Screenshot_20250924_172634" src="https://github.com/user-attachments/assets/5ef72f59-b0d1-4a5f-87f9-d2ae8d02d65f" />
<img width="1080" height="2400" alt="Screenshot_20250924_172645" src="https://github.com/user-attachments/assets/2c7bfad8-7d70-4dea-a6d4-e2d11cf3a3af" />
<img width="1080" height="2400" alt="Screenshot_20250924_172652" src="https://github.com/user-attachments/assets/3966d91b-38a9-4ce8-a72f-dc8d7d83e175" />
