### PR TITLE
Add F1 league and Grand Prix support to event forms

### DIFF
--- a/app/src/main/java/com/example/mobilecomputingassignment/data/constants/TeamConstants.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/data/constants/TeamConstants.kt
@@ -9,184 +9,214 @@ import com.example.mobilecomputingassignment.domain.models.Team
  */
 object TeamConstants {
 
-  /**
-   * All AFL teams as constant data Based on Squiggle API response from
-   * https://api.squiggle.com.au/?q=teams
-   */
-  val AFL_TEAMS =
-          listOf(
-                  Team(
-                          id = 1,
-                          name = "Adelaide",
-                          abbreviation = "ADE",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Adelaide")
-                  ),
-                  Team(
-                          id = 2,
-                          name = "Brisbane Lions",
-                          abbreviation = "BRI",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Brisbane Lions")
-                  ),
-                  Team(
-                          id = 3,
-                          name = "Carlton",
-                          abbreviation = "CAR",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Carlton")
-                  ),
-                  Team(
-                          id = 4,
-                          name = "Collingwood",
-                          abbreviation = "COL",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Collingwood")
-                  ),
-                  Team(
-                          id = 5,
-                          name = "Essendon",
-                          abbreviation = "ESS",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Essendon")
-                  ),
-                  Team(
-                          id = 6,
-                          name = "Fremantle",
-                          abbreviation = "FRE",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Fremantle")
-                  ),
-                  Team(
-                          id = 7,
-                          name = "Geelong",
-                          abbreviation = "GEE",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Geelong")
-                  ),
-                  Team(
-                          id = 8,
-                          name = "Gold Coast",
-                          abbreviation = "GCS",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Gold Coast")
-                  ),
-                  Team(
-                          id = 9,
-                          name = "Greater Western Sydney",
-                          abbreviation = "GWS",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Greater Western Sydney")
-                  ),
-                  Team(
-                          id = 10,
-                          name = "Hawthorn",
-                          abbreviation = "HAW",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Hawthorn")
-                  ),
-                  Team(
-                          id = 11,
-                          name = "Melbourne",
-                          abbreviation = "MEL",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Melbourne")
-                  ),
-                  Team(
-                          id = 12,
-                          name = "North Melbourne",
-                          abbreviation = "NOR",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("North Melbourne")
-                  ),
-                  Team(
-                          id = 13,
-                          name = "Port Adelaide",
-                          abbreviation = "POR",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Port Adelaide")
-                  ),
-                  Team(
-                          id = 14,
-                          name = "Richmond",
-                          abbreviation = "RIC",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Richmond")
-                  ),
-                  Team(
-                          id = 15,
-                          name = "St Kilda",
-                          abbreviation = "STK",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("St Kilda")
-                  ),
-                  Team(
-                          id = 16,
-                          name = "Sydney",
-                          abbreviation = "SYD",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Sydney")
-                  ),
-                  Team(
-                          id = 17,
-                          name = "West Coast",
-                          abbreviation = "WCE",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("West Coast")
-                  ),
-                  Team(
-                          id = 18,
-                          name = "Western Bulldogs",
-                          abbreviation = "WBD",
-                          league = "AFL",
-                          localLogoRes = TeamLogoMapper.getTeamLogoByName("Western Bulldogs")
-                  )
-          )
+        /**
+         * All AFL teams as constant data Based on Squiggle API response from
+         * https://api.squiggle.com.au/?q=teams
+         */
+        val AFL_TEAMS =
+                listOf(
+                        Team(
+                                id = 1,
+                                name = "Adelaide",
+                                abbreviation = "ADE",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("Adelaide")
+                        ),
+                        Team(
+                                id = 2,
+                                name = "Brisbane Lions",
+                                abbreviation = "BRI",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("Brisbane Lions")
+                        ),
+                        Team(
+                                id = 3,
+                                name = "Carlton",
+                                abbreviation = "CAR",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("Carlton")
+                        ),
+                        Team(
+                                id = 4,
+                                name = "Collingwood",
+                                abbreviation = "COL",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("Collingwood")
+                        ),
+                        Team(
+                                id = 5,
+                                name = "Essendon",
+                                abbreviation = "ESS",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("Essendon")
+                        ),
+                        Team(
+                                id = 6,
+                                name = "Fremantle",
+                                abbreviation = "FRE",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("Fremantle")
+                        ),
+                        Team(
+                                id = 7,
+                                name = "Geelong",
+                                abbreviation = "GEE",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("Geelong")
+                        ),
+                        Team(
+                                id = 8,
+                                name = "Gold Coast",
+                                abbreviation = "GCS",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("Gold Coast")
+                        ),
+                        Team(
+                                id = 9,
+                                name = "Greater Western Sydney",
+                                abbreviation = "GWS",
+                                league = "AFL",
+                                localLogoRes =
+                                        TeamLogoMapper.getTeamLogoByName("Greater Western Sydney")
+                        ),
+                        Team(
+                                id = 10,
+                                name = "Hawthorn",
+                                abbreviation = "HAW",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("Hawthorn")
+                        ),
+                        Team(
+                                id = 11,
+                                name = "Melbourne",
+                                abbreviation = "MEL",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("Melbourne")
+                        ),
+                        Team(
+                                id = 12,
+                                name = "North Melbourne",
+                                abbreviation = "NOR",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("North Melbourne")
+                        ),
+                        Team(
+                                id = 13,
+                                name = "Port Adelaide",
+                                abbreviation = "POR",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("Port Adelaide")
+                        ),
+                        Team(
+                                id = 14,
+                                name = "Richmond",
+                                abbreviation = "RIC",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("Richmond")
+                        ),
+                        Team(
+                                id = 15,
+                                name = "St Kilda",
+                                abbreviation = "STK",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("St Kilda")
+                        ),
+                        Team(
+                                id = 16,
+                                name = "Sydney",
+                                abbreviation = "SYD",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("Sydney")
+                        ),
+                        Team(
+                                id = 17,
+                                name = "West Coast",
+                                abbreviation = "WCE",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("West Coast")
+                        ),
+                        Team(
+                                id = 18,
+                                name = "Western Bulldogs",
+                                abbreviation = "WBD",
+                                league = "AFL",
+                                localLogoRes = TeamLogoMapper.getTeamLogoByName("Western Bulldogs")
+                        )
+                )
 
-  /**
-   * Get teams by league name
-   * @param leagueName The league name (e.g., "AFL")
-   * @return List of teams in the specified league
-   */
-  fun getTeams(leagueName: String): List<Team> {
-    return when (leagueName.uppercase()) {
-      "AFL" -> AFL_TEAMS
-      else -> emptyList()
-    }
-  }
+        /** List of all F1 Grand Prix races in the 2024 season */
+        val F1_GRAND_PRIX =
+                arrayOf(
+                        "Bahrain Grand Prix",
+                        "Saudi Arabian Grand Prix",
+                        "Australian Grand Prix",
+                        "Japanese Grand Prix",
+                        "Chinese Grand Prix",
+                        "Miami Grand Prix",
+                        "Emilia Romagna Grand Prix",
+                        "Monaco Grand Prix",
+                        "Canadian Grand Prix",
+                        "Spanish Grand Prix",
+                        "Austrian Grand Prix",
+                        "British Grand Prix",
+                        "Hungarian Grand Prix",
+                        "Belgian Grand Prix",
+                        "Dutch Grand Prix",
+                        "Italian Grand Prix",
+                        "Azerbaijan Grand Prix",
+                        "Singapore Grand Prix",
+                        "United States Grand Prix",
+                        "Mexico City Grand Prix",
+                        "São Paulo Grand Prix",
+                        "Las Vegas Grand Prix",
+                        "Qatar Grand Prix",
+                        "Abu Dhabi Grand Prix"
+                )
 
-  /**
-   * Get all available leagues
-   * @return Set of available league names
-   */
-  fun getAvailableLeagues(): Set<String> {
-    return setOf("AFL")
-  }
+        /**
+         * Get teams by league name
+         * @param leagueName The league name (e.g., "AFL")
+         * @return List of teams in the specified league
+         */
+        fun getTeams(leagueName: String): List<Team> {
+                return when (leagueName.uppercase()) {
+                        "AFL" -> AFL_TEAMS
+                        else -> emptyList()
+                }
+        }
 
-  /**
-   * Get team by ID
-   * @param teamId The team ID
-   * @return Team if found, null otherwise
-   */
-  fun getTeamById(teamId: Int): Team? {
-    return AFL_TEAMS.find { it.id == teamId }
-  }
+        /**
+         * Get all available leagues
+         * @return Set of available league names
+         */
+        fun getAvailableLeagues(): Set<String> {
+                return setOf("AFL", "F1")
+        }
 
-  /**
-   * Get team by name
-   * @param teamName The team name
-   * @return Team if found, null otherwise
-   */
-  fun getTeamByName(teamName: String): Team? {
-    return AFL_TEAMS.find { it.name.equals(teamName, ignoreCase = true) }
-  }
+        /**
+         * Get team by ID
+         * @param teamId The team ID
+         * @return Team if found, null otherwise
+         */
+        fun getTeamById(teamId: Int): Team? {
+                return AFL_TEAMS.find { it.id == teamId }
+        }
 
-  /**
-   * Get team by abbreviation
-   * @param abbreviation The team abbreviation
-   * @return Team if found, null otherwise
-   */
-  fun getTeamByAbbreviation(abbreviation: String): Team? {
-    return AFL_TEAMS.find { it.abbreviation.equals(abbreviation, ignoreCase = true) }
-  }
+        /**
+         * Get team by name
+         * @param teamName The team name
+         * @return Team if found, null otherwise
+         */
+        fun getTeamByName(teamName: String): Team? {
+                return AFL_TEAMS.find { it.name.equals(teamName, ignoreCase = true) }
+        }
+
+        /**
+         * Get team by abbreviation
+         * @param abbreviation The team abbreviation
+         * @return Team if found, null otherwise
+         */
+        fun getTeamByAbbreviation(abbreviation: String): Team? {
+                return AFL_TEAMS.find { it.abbreviation.equals(abbreviation, ignoreCase = true) }
+        }
 }

--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/screens/explore/components/EventDetailsDialog.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/screens/explore/components/EventDetailsDialog.kt
@@ -46,19 +46,32 @@ fun EventDetailsDialog(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Teams
+        // Teams or League Logo
+        val isF1Event = event.matchDetails?.competition == "F1"
+        
         Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
+                horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
         ) {
-          TeamLogo(teamName = event.matchDetails?.homeTeam ?: "TBD")
-          Text(
-                  text = "VS",
-                  style = MaterialTheme.typography.titleLarge,
-                  color = MaterialTheme.colorScheme.primary
-          )
-          TeamLogo(teamName = event.matchDetails?.awayTeam ?: "TBD")
+          if (isF1Event) {
+            // F1 Event - Show F1 logo
+            androidx.compose.foundation.Image(
+                    painter = painterResource(id = R.drawable.league_f1),
+                    contentDescription = "F1",
+                    modifier = Modifier.size(80.dp)
+            )
+          } else {
+            // AFL Event - Show team logos
+            TeamLogo(teamName = event.matchDetails?.homeTeam ?: "TBD")
+            Text(
+                    text = "VS",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(horizontal = 16.dp)
+            )
+            TeamLogo(teamName = event.matchDetails?.awayTeam ?: "TBD")
+          }
         }
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/screens/explore/components/MatchDetailDrawer.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/screens/explore/components/MatchDetailDrawer.kt
@@ -295,9 +295,7 @@ fun MatchDetailDrawer(
 
 @Composable
 private fun TeamsSection(event: Event) {
-    // Add null safety for match details
-    val homeTeam = event.matchDetails?.homeTeam?.takeIf { it.isNotBlank() } ?: "TBD"
-    val awayTeam = event.matchDetails?.awayTeam?.takeIf { it.isNotBlank() } ?: "TBD"
+    val isF1Event = event.matchDetails?.competition == "F1"
     
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -318,50 +316,70 @@ private fun TeamsSection(event: Event) {
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // Home team
-                Column(horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.weight(1f)) {
-                    TeamLogo(
-                        teamName = homeTeam,
-                        modifier = Modifier.size(64.dp)
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        text = homeTeam,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium,
-                        modifier = Modifier.fillMaxWidth(),
-                        textAlign = TextAlign.Center
-                    )
-                }
-
-                Text(
-                    text = "VS",
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(horizontal = 8.dp)
+            if (isF1Event) {
+                // F1 Event - Show F1 logo
+                androidx.compose.foundation.Image(
+                        painter = painterResource(id = R.drawable.league_f1),
+                        contentDescription = "F1",
+                        modifier = Modifier.size(80.dp)
                 )
-
-                // Away team
-                Column(horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.weight(1f)) {
-                    TeamLogo(
-                        teamName = awayTeam,
-                        modifier = Modifier.size(64.dp)
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        text = awayTeam,
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                        text = event.matchDetails?.venue ?: "F1 Grand Prix",
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.Medium,
-                        modifier = Modifier.fillMaxWidth(),
                         textAlign = TextAlign.Center
-                    )
+                )
+            } else {
+                // AFL Event - Show team vs team
+                val homeTeam = event.matchDetails?.homeTeam?.takeIf { it.isNotBlank() } ?: "TBD"
+                val awayTeam = event.matchDetails?.awayTeam?.takeIf { it.isNotBlank() } ?: "TBD"
+                
+                Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                ) {
+                        // Home team
+                        Column(horizontalAlignment = Alignment.CenterHorizontally,
+                                modifier = Modifier.weight(1f)) {
+                                TeamLogo(
+                                        teamName = homeTeam,
+                                        modifier = Modifier.size(64.dp)
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                        text = homeTeam,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        fontWeight = FontWeight.Medium,
+                                        modifier = Modifier.fillMaxWidth(),
+                                        textAlign = TextAlign.Center
+                                )
+                        }
+
+                        Text(
+                                text = "VS",
+                                style = MaterialTheme.typography.titleLarge,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.padding(horizontal = 8.dp)
+                        )
+
+                        // Away team
+                        Column(horizontalAlignment = Alignment.CenterHorizontally,
+                                modifier = Modifier.weight(1f)) {
+                                TeamLogo(
+                                        teamName = awayTeam,
+                                        modifier = Modifier.size(64.dp)
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                        text = awayTeam,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        fontWeight = FontWeight.Medium,
+                                        modifier = Modifier.fillMaxWidth(),
+                                        textAlign = TextAlign.Center
+                                )
+                        }
                 }
             }
         }

--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/component/EventCard.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/component/EventCard.kt
@@ -19,8 +19,6 @@ import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Info
-import androidx.compose.ui.res.painterResource
-import com.example.mobilecomputingassignment.R
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material3.AlertDialog
@@ -45,9 +43,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.example.mobilecomputingassignment.R
 import com.example.mobilecomputingassignment.domain.models.Event
 import com.example.mobilecomputingassignment.presentation.utils.EventDateUtils
 import java.text.SimpleDateFormat
@@ -56,14 +56,14 @@ import java.util.Locale
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EventCard(
-    event: Event,
-    isHosted: Boolean = false,
-    onToggleInterest: (() -> Unit)? = null,
-    onCheckIn: (() -> Unit)? = null,
-    onGetDirections: (() -> Unit)? = null,
-    onEditEvent: (() -> Unit)? = null,
-    onDeleteEvent: (() -> Unit)? = null,
-    modifier: Modifier = Modifier
+        event: Event,
+        isHosted: Boolean = false,
+        onToggleInterest: (() -> Unit)? = null,
+        onCheckIn: (() -> Unit)? = null,
+        onGetDirections: (() -> Unit)? = null,
+        onEditEvent: (() -> Unit)? = null,
+        onDeleteEvent: (() -> Unit)? = null,
+        modifier: Modifier = Modifier
 ) {
     var showDeleteDialog by remember { mutableStateOf(false) }
 
@@ -72,58 +72,62 @@ fun EventCard(
     val cardAlpha = if (isEventInPast) 0.33f else 1.0f
 
     // Separate the "- [Event Venue]" from event.title (since it repeats in event.description)
-    val cleanTitle = event.title.split("-").first().trim().replace(" vs ", " vs \n")
+    val isF1Event = event.matchDetails?.competition == "F1"
+    val cleanTitle = if (isF1Event) {
+        // For F1 events, show "F1" instead of team vs team
+        "F1"
+    } else {
+        // For AFL events, keep the team vs team format
+        event.title.split("-").first().trim().replace(" vs ", " vs \n")
+    }
 
     Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .alpha(cardAlpha),
-        shape = RoundedCornerShape(20.dp),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
-        colors =
-            CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface,
-                contentColor = MaterialTheme.colorScheme.onSurface
-            )
+            modifier = modifier.fillMaxWidth().alpha(cardAlpha),
+            shape = RoundedCornerShape(20.dp),
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
+            colors =
+                    CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surface,
+                            contentColor = MaterialTheme.colorScheme.onSurface
+                    )
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .background(
-                            color =
-                                MaterialTheme.colorScheme.primaryContainer.copy(
-                                    alpha = 0.3f
-                                ),
-                            shape = RoundedCornerShape(12.dp)
-                        )
-                        .padding(16.dp)
+                    modifier =
+                            Modifier.fillMaxWidth()
+                                    .background(
+                                            color =
+                                                    MaterialTheme.colorScheme.primaryContainer.copy(
+                                                            alpha = 0.3f
+                                                    ),
+                                            shape = RoundedCornerShape(12.dp)
+                                    )
+                                    .padding(16.dp)
             ) {
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.Top
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.Top
                 ) {
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
-                            text = cleanTitle,
-                            style = MaterialTheme.typography.titleLarge,
-                            fontWeight = FontWeight.ExtraBold,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis,
-                            color = MaterialTheme.colorScheme.primary
+                                text = cleanTitle,
+                                style = MaterialTheme.typography.titleLarge,
+                                fontWeight = FontWeight.ExtraBold,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                                color = MaterialTheme.colorScheme.primary
                         )
 
                         if (event.description.isNotBlank()) {
                             Spacer(modifier = Modifier.height(6.dp))
                             Text(
-                                text = event.description,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis,
-                                fontWeight = FontWeight.Medium
+                                    text = event.description,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis,
+                                    fontWeight = FontWeight.Medium
                             )
                         }
                     }
@@ -133,68 +137,76 @@ fun EventCard(
                         if (isHosted && !isEventInPast) {
                             // Edit button with circular background
                             Box(
-                                modifier =
-                                    Modifier
-                                        .size(40.dp)
-                                        .background(
-                                            MaterialTheme.colorScheme
-                                                .primaryContainer,
-                                            CircleShape
-                                        ),
-                                contentAlignment = Alignment.Center
+                                    modifier =
+                                            Modifier.size(40.dp)
+                                                    .background(
+                                                            MaterialTheme.colorScheme
+                                                                    .primaryContainer,
+                                                            CircleShape
+                                                    ),
+                                    contentAlignment = Alignment.Center
                             ) {
                                 IconButton(onClick = { onEditEvent?.invoke() }) {
                                     Icon(
-                                        imageVector = Icons.Default.Edit,
-                                        contentDescription = "Edit Event",
-                                        tint = MaterialTheme.colorScheme.primary,
-                                        modifier = Modifier.size(20.dp)
+                                            imageVector = Icons.Default.Edit,
+                                            contentDescription = "Edit Event",
+                                            tint = MaterialTheme.colorScheme.primary,
+                                            modifier = Modifier.size(20.dp)
                                     )
                                 }
                             }
 
                             // Delete button with circular background
                             Box(
-                                modifier =
-                                    Modifier
-                                        .size(40.dp)
-                                        .background(
-                                            MaterialTheme.colorScheme
-                                                .errorContainer,
-                                            CircleShape
-                                        ),
-                                contentAlignment = Alignment.Center
+                                    modifier =
+                                            Modifier.size(40.dp)
+                                                    .background(
+                                                            MaterialTheme.colorScheme
+                                                                    .errorContainer,
+                                                            CircleShape
+                                                    ),
+                                    contentAlignment = Alignment.Center
                             ) {
                                 IconButton(onClick = { showDeleteDialog = true }) {
                                     Icon(
-                                        imageVector = Icons.Default.Delete,
-                                        contentDescription = "Delete Event",
-                                        tint = MaterialTheme.colorScheme.error,
-                                        modifier = Modifier.size(20.dp)
+                                            imageVector = Icons.Default.Delete,
+                                            contentDescription = "Delete Event",
+                                            tint = MaterialTheme.colorScheme.error,
+                                            modifier = Modifier.size(20.dp)
                                     )
                                 }
                             }
-//                        } else {
-//                            // Interest button with circular background [REMOVED FOR NOW]
-//                            Box(
-//                                    modifier =
-//                                            Modifier.size(40.dp)
-//                                                    .background(
-//                                                            MaterialTheme.colorScheme
-//                                                                    .tertiaryContainer,
-//                                                            CircleShape
-//                                                    ),
-//                                    contentAlignment = Alignment.Center
-//                            ) {
-//                                IconButton(onClick = { onToggleInterest?.invoke() }) {
-//                                    Icon(
-//                                            imageVector = Icons.Default.Favorite,
-//                                            contentDescription = "Toggle Interest",
-//                                            tint = MaterialTheme.colorScheme.tertiary,
-//                                            modifier = Modifier.size(20.dp)
-//                                    )
-//                                }
-//                            }
+                            //                        } else {
+                            //                            // Interest button with circular
+                            // background [REMOVED FOR NOW]
+                            //                            Box(
+                            //                                    modifier =
+                            //                                            Modifier.size(40.dp)
+                            //                                                    .background(
+                            //
+                            // MaterialTheme.colorScheme
+                            //
+                            // .tertiaryContainer,
+                            //
+                            // CircleShape
+                            //                                                    ),
+                            //                                    contentAlignment =
+                            // Alignment.Center
+                            //                            ) {
+                            //                                IconButton(onClick = {
+                            // onToggleInterest?.invoke() }) {
+                            //                                    Icon(
+                            //                                            imageVector =
+                            // Icons.Default.Favorite,
+                            //                                            contentDescription =
+                            // "Toggle Interest",
+                            //                                            tint =
+                            // MaterialTheme.colorScheme.tertiary,
+                            //                                            modifier =
+                            // Modifier.size(20.dp)
+                            //                                    )
+                            //                                }
+                            //                            }
                         }
                     }
                 }
@@ -203,89 +215,100 @@ fun EventCard(
             if (!isEventInPast) {
                 Spacer(modifier = Modifier.height(12.dp))
 
-                // Team logos before event details
+                // Team logos or F1 logo before event details
+
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
                 ) {
-                    TeamLogo(
-                        teamName = event.matchDetails?.homeTeam ?: "TBD",
-                        modifier = Modifier.size(64.dp)
-                    )
+                    if (isF1Event) {
+                        // F1 Event - Show F1 logo
+                        androidx.compose.foundation.Image(
+                                painter = painterResource(id = R.drawable.league_f1),
+                                contentDescription = "F1",
+                                modifier = Modifier.size(80.dp)
+                        )
+                    } else {
+                        // AFL Event - Show team logos
+                        TeamLogo(
+                                teamName = event.matchDetails?.homeTeam ?: "TBD",
+                                modifier = Modifier.size(64.dp)
+                        )
 
-                    Spacer(modifier = Modifier.width(12.dp))
+                        Spacer(modifier = Modifier.width(12.dp))
 
-                    Text(
-                        text = "vs",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
+                        Text(
+                                text = "vs",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSurface
+                        )
 
-                    Spacer(modifier = Modifier.width(12.dp))
+                        Spacer(modifier = Modifier.width(12.dp))
 
-                    TeamLogo(
-                        teamName = event.matchDetails?.awayTeam ?: "TBD",
-                        modifier = Modifier.size(64.dp)
-                    )
+                        TeamLogo(
+                                teamName = event.matchDetails?.awayTeam ?: "TBD",
+                                modifier = Modifier.size(64.dp)
+                        )
+                    }
                 }
                 // Event details in nested card
                 Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors =
-                        CardDefaults.cardColors(
-                            containerColor =
-                                MaterialTheme.colorScheme.surfaceVariant.copy(
-                                    alpha = 0.3f
-                                )
-                        ),
-                    shape = RoundedCornerShape(12.dp)
+                        modifier = Modifier.fillMaxWidth(),
+                        colors =
+                                CardDefaults.cardColors(
+                                        containerColor =
+                                                MaterialTheme.colorScheme.surfaceVariant.copy(
+                                                        alpha = 0.3f
+                                                )
+                                ),
+                        shape = RoundedCornerShape(12.dp)
                 ) {
                     Column(modifier = Modifier.padding(16.dp)) {
                         Text(
-                            text = event.location.name,
-                            style = MaterialTheme.typography.titleLarge,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            modifier = Modifier.padding(vertical = 4.dp)
+                                text = event.location.name,
+                                style = MaterialTheme.typography.titleLarge,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.padding(vertical = 4.dp)
                         )
 
                         if (event.location.address.isNotBlank()) {
                             Text(
-                                text = event.location.address,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-                                modifier = Modifier.padding(bottom = 8.dp)
+                                    text = event.location.address,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+                                    modifier = Modifier.padding(bottom = 8.dp)
                             )
                         }
 
                         EventDetailRow(
-                            icon = Icons.Default.DateRange,
-                            label = "Date",
-                            value =
-                                SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
-                                    .format(event.date)
+                                icon = Icons.Default.DateRange,
+                                label = "Date",
+                                value =
+                                        SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+                                                .format(event.date)
                         )
 
                         EventDetailRow(
-                            icon = Icons.Default.Info,
-                            label = "Time",
-                            value =
-                                SimpleDateFormat("HH:mm", Locale.getDefault())
-                                    .format(event.checkInTime)
+                                icon = Icons.Default.Info,
+                                label = "Time",
+                                value =
+                                        SimpleDateFormat("HH:mm", Locale.getDefault())
+                                                .format(event.checkInTime)
                         )
 
                         EventDetailRow(
-                            icon = Icons.Default.Person,
-                            label = "Capacity",
-                            value = "${event.attendeesCount}/${event.capacity}"
+                                icon = Icons.Default.Person,
+                                label = "Capacity",
+                                value = "${event.attendeesCount}/${event.capacity}"
                         )
                         if (event.contactNumber.isNotBlank()) {
                             EventDetailRow(
-                                icon = Icons.Default.Phone,
-                                label = "Contact",
-                                value = event.contactNumber
+                                    icon = Icons.Default.Phone,
+                                    label = "Contact",
+                                    value = event.contactNumber
                             )
                         }
                     }
@@ -294,16 +317,16 @@ fun EventCard(
 
             // Amenities and accessibility indicators
             if (event.amenities.isIndoor ||
-                event.amenities.isOutdoor ||
-                event.amenities.isChildFriendly ||
-                event.amenities.isPetFriendly
+                            event.amenities.isOutdoor ||
+                            event.amenities.isChildFriendly ||
+                            event.amenities.isPetFriendly
             ) {
 
                 Spacer(modifier = Modifier.height(8.dp))
 
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    modifier = Modifier.fillMaxWidth()
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.fillMaxWidth()
                 ) {
                     if (event.amenities.isIndoor) {
                         AmenityChip("Indoor")
@@ -325,17 +348,17 @@ fun EventCard(
                 Spacer(modifier = Modifier.height(12.dp))
 
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     OutlinedButton(
-                        onClick = { onToggleInterest?.invoke() },
-                        modifier = Modifier.weight(1f)
+                            onClick = { onToggleInterest?.invoke() },
+                            modifier = Modifier.weight(1f)
                     ) { Text("Uninterest") }
 
                     Button(
-                        onClick = { onGetDirections?.invoke() ?: onCheckIn?.invoke() },
-                        modifier = Modifier.weight(1f)
+                            onClick = { onGetDirections?.invoke() ?: onCheckIn?.invoke() },
+                            modifier = Modifier.weight(1f)
                     ) { Text(if (onGetDirections != null) "Directions" else "Check In") }
                 }
             }
@@ -345,70 +368,67 @@ fun EventCard(
     // Delete confirmation dialog
     if (showDeleteDialog) {
         AlertDialog(
-            onDismissRequest = { showDeleteDialog = false },
-            title = { Text("Delete Event") },
-            text = {
-                Text(
-                    "Are you sure you want to delete this event? This action cannot be undone."
-                )
-            },
-            confirmButton = {
-                Button(
-                    onClick = {
-                        showDeleteDialog = false
-                        onDeleteEvent?.invoke()
-                    },
-                    colors =
-                        ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.error
-                        )
-                ) { Text("Delete") }
-            },
-            dismissButton = {
-                TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel") }
-            }
+                onDismissRequest = { showDeleteDialog = false },
+                title = { Text("Delete Event") },
+                text = {
+                    Text(
+                            "Are you sure you want to delete this event? This action cannot be undone."
+                    )
+                },
+                confirmButton = {
+                    Button(
+                            onClick = {
+                                showDeleteDialog = false
+                                onDeleteEvent?.invoke()
+                            },
+                            colors =
+                                    ButtonDefaults.buttonColors(
+                                            containerColor = MaterialTheme.colorScheme.error
+                                    )
+                    ) { Text("Delete") }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel") }
+                }
         )
     }
 }
 
 @Composable
 private fun EventDetailRow(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
-    label: String,
-    value: String,
-    modifier: Modifier = Modifier
+        icon: androidx.compose.ui.graphics.vector.ImageVector,
+        label: String,
+        value: String,
+        modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(vertical = 2.dp),
-        verticalAlignment = Alignment.CenterVertically
+            modifier = modifier.fillMaxWidth().padding(vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically
     ) {
         Box(
-            modifier =
-                Modifier
-                    .size(32.dp)
-                    .background(
-                        MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
-                        CircleShape
-                    ),
-            contentAlignment = Alignment.Center
+                modifier =
+                        Modifier.size(32.dp)
+                                .background(
+                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
+                                        CircleShape
+                                ),
+                contentAlignment = Alignment.Center
         ) {
             Icon(
-                imageVector = icon,
-                contentDescription = null,
-                modifier = Modifier.size(18.dp),
-                tint = MaterialTheme.colorScheme.primary
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.primary
             )
         }
 
         Spacer(modifier = Modifier.width(12.dp))
 
         Text(
-            text = value,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            fontWeight = FontWeight.Medium
+                text = value,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Medium
         )
     }
 }
@@ -416,56 +436,51 @@ private fun EventDetailRow(
 @Composable
 private fun AmenityChip(text: String, modifier: Modifier = Modifier) {
     AssistChip(
-        onClick = {},
-        label = { Text(text = text, style = MaterialTheme.typography.labelSmall) },
-        modifier = modifier,
-        colors =
-            AssistChipDefaults.assistChipColors(
-                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                labelColor = MaterialTheme.colorScheme.onPrimaryContainer
-            )
+            onClick = {},
+            label = { Text(text = text, style = MaterialTheme.typography.labelSmall) },
+            modifier = modifier,
+            colors =
+                    AssistChipDefaults.assistChipColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                            labelColor = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
     )
 }
 
 // Overloaded version that accepts drawable resource ID
 @Composable
 private fun EventDetailRow(
-    iconResId: Int,
-    label: String,
-    value: String,
-    modifier: Modifier = Modifier
+        iconResId: Int,
+        label: String,
+        value: String,
+        modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(vertical = 2.dp),
-        verticalAlignment = Alignment.CenterVertically
+            modifier = modifier.fillMaxWidth().padding(vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically
     ) {
         Box(
-            modifier =
-                Modifier
-                    .size(20.dp)
-                    .padding(end = 8.dp),
-            contentAlignment = Alignment.Center
+                modifier = Modifier.size(20.dp).padding(end = 8.dp),
+                contentAlignment = Alignment.Center
         ) {
             Icon(
-                painter = painterResource(id = iconResId),
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(16.dp)
+                    painter = painterResource(id = iconResId),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(16.dp)
             )
         }
         Text(
-            text = label,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.Medium,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.width(80.dp)
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.width(80.dp)
         )
         Text(
-            text = value,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface
+                text = value,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
         )
     }
 }

--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/component/EventFormDialog.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/component/EventFormDialog.kt
@@ -33,9 +33,9 @@ import com.example.mobilecomputingassignment.R
 import com.example.mobilecomputingassignment.domain.models.Team
 import com.example.mobilecomputingassignment.presentation.utils.TimezoneUtils
 import com.example.mobilecomputingassignment.presentation.viewmodel.EventViewModel
+import java.text.SimpleDateFormat
 import java.util.*
 import java.util.Calendar
-import java.text.SimpleDateFormat
 
 @Composable
 private fun EventFormSection(
@@ -49,12 +49,12 @@ private fun EventFormSection(
                 Row(
                         modifier =
                                 Modifier.fillMaxWidth()
-                                .clickable(
+                                        .clickable(
                                                 interactionSource =
                                                         remember { MutableInteractionSource() },
-                                        indication = null
-                                ) { onHeaderClick() }
-                                .padding(vertical = 8.dp),
+                                                indication = null
+                                        ) { onHeaderClick() }
+                                        .padding(vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically
                 ) {
                         Icon(
@@ -315,7 +315,11 @@ fun EventFormDialog(
 
                                                         // Date picker
                                                         OutlinedTextField(
-                                                                value = TimezoneUtils.formatPreservedDate(formData.date),
+                                                                value =
+                                                                        TimezoneUtils
+                                                                                .formatPreservedDate(
+                                                                                        formData.date
+                                                                                ),
                                                                 onValueChange = {},
                                                                 label = { Text("Event Date *") },
                                                                 modifier = Modifier.weight(1f),
@@ -323,8 +327,8 @@ fun EventFormDialog(
                                                                 trailingIcon = {
                                                                         IconButton(
                                                                                 onClick = {
-                                                                                showDatePicker =
-                                                                                        true
+                                                                                        showDatePicker =
+                                                                                                true
                                                                                 }
                                                                         ) {
                                                                                 Icon(
@@ -347,7 +351,11 @@ fun EventFormDialog(
 
                                                         // Time picker
                                                         OutlinedTextField(
-                                                                value = TimezoneUtils.formatPreservedTime(formData.checkInTime),
+                                                                value =
+                                                                        TimezoneUtils
+                                                                                .formatPreservedTime(
+                                                                                        formData.checkInTime
+                                                                                ),
                                                                 onValueChange = {},
                                                                 label = { Text("Match Time *") },
                                                                 modifier = Modifier.weight(1f),
@@ -355,8 +363,8 @@ fun EventFormDialog(
                                                                 trailingIcon = {
                                                                         IconButton(
                                                                                 onClick = {
-                                                                                showTimePicker =
-                                                                                        true
+                                                                                        showTimePicker =
+                                                                                                true
                                                                                 }
                                                                         ) {
                                                                                 Icon(
@@ -396,7 +404,7 @@ fun EventFormDialog(
                                                                                         datePickerState
                                                                                                 .selectedDateMillis
                                                                                                 ?.let {
-                                                                                                                        millis
+                                                                                                        millis
                                                                                                         ->
                                                                                                         // Create date in Australian timezone to match validation logic
                                                                                                         val calendar =
@@ -414,13 +422,13 @@ fun EventFormDialog(
                                                                                                                 // Only reset selectedMatch when the user actually picked a different date
                                                                                                                 eventViewModel
                                                                                                                         .updateFormData(
-                                                                                                                        formData.copy(
+                                                                                                                                formData.copy(
                                                                                                                                         date =
                                                                                                                                                 newDate,
                                                                                                                                         selectedMatch =
                                                                                                                                                 null
+                                                                                                                                )
                                                                                                                         )
-                                                                                                                )
                                                                                                         }
                                                                                                 }
                                                                                         showDatePicker =
@@ -433,7 +441,7 @@ fun EventFormDialog(
                                                                                                                 MaterialTheme
                                                                                                                         .colorScheme
                                                                                                                         .primary
-                                                                                )
+                                                                                                )
                                                                         ) { Text("OK") }
                                                                 },
                                                                 dismissButton = {
@@ -449,7 +457,7 @@ fun EventFormDialog(
                                                                                                                 MaterialTheme
                                                                                                                         .colorScheme
                                                                                                                         .onSurfaceVariant
-                                                                                )
+                                                                                                )
                                                                         ) { Text("Cancel") }
                                                                 },
                                                                 colors =
@@ -545,8 +553,8 @@ fun EventFormDialog(
                                                                                                 .copy(
                                                                                                         alpha =
                                                                                                                 0.12f
+                                                                                                )
                                                                         )
-                                                                )
                                                         ) {
                                                                 DatePicker(
                                                                         state = datePickerState,
@@ -557,10 +565,12 @@ fun EventFormDialog(
 
                                                 // Time picker dialog
                                                 if (showTimePicker) {
-                                                        // Read time directly without timezone conversion
+                                                        // Read time directly without timezone
+                                                        // conversion
                                                         val calendar = Calendar.getInstance()
                                                         calendar.time = formData.checkInTime
-                                                        val hour = calendar.get(Calendar.HOUR_OF_DAY)
+                                                        val hour =
+                                                                calendar.get(Calendar.HOUR_OF_DAY)
                                                         val minute = calendar.get(Calendar.MINUTE)
 
                                                         val timePickerState =
@@ -641,45 +651,83 @@ fun EventFormDialog(
                                                                                                                 MaterialTheme
                                                                                                                         .colorScheme
                                                                                                                         .onSurface
-                                                                                )
+                                                                                                )
                                                                         )
                                                                 },
                                                                 confirmButton = {
                                                                         TextButton(
                                                                                 onClick = {
-                                                                                        // Create time directly without timezone conversion
-                                                                                        val calendar = Calendar.getInstance()
-                                                                                        calendar.time = formData.date
-                                                                                        calendar.set(Calendar.HOUR_OF_DAY, timePickerState.hour)
-                                                                                        calendar.set(Calendar.MINUTE, timePickerState.minute)
-                                                                                        calendar.set(Calendar.SECOND, 0)
-                                                                                        calendar.set(Calendar.MILLISECOND, 0)
-                                                                                        val newTime = calendar.time
-                                                                                        
-                                                                                        // Debug logging
-                                                                                        android.util.Log.d("EventFormDialog", "Time picker selected: ${timePickerState.hour}:${timePickerState.minute}")
-                                                                                        android.util.Log.d("EventFormDialog", "New time created: ${newTime}")
-                                                                                        android.util.Log.d("EventFormDialog", "New time formatted: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(newTime)}")
+                                                                                        // Create
+                                                                                        // time
+                                                                                        // directly
+                                                                                        // without
+                                                                                        // timezone
+                                                                                        // conversion
+                                                                                        val calendar =
+                                                                                                Calendar.getInstance()
+                                                                                        calendar.time =
+                                                                                                formData.date
+                                                                                        calendar.set(
+                                                                                                Calendar.HOUR_OF_DAY,
+                                                                                                timePickerState
+                                                                                                        .hour
+                                                                                        )
+                                                                                        calendar.set(
+                                                                                                Calendar.MINUTE,
+                                                                                                timePickerState
+                                                                                                        .minute
+                                                                                        )
+                                                                                        calendar.set(
+                                                                                                Calendar.SECOND,
+                                                                                                0
+                                                                                        )
+                                                                                        calendar.set(
+                                                                                                Calendar.MILLISECOND,
+                                                                                                0
+                                                                                        )
+                                                                                        val newTime =
+                                                                                                calendar.time
+
+                                                                                        // Debug
+                                                                                        // logging
+                                                                                        android.util
+                                                                                                .Log
+                                                                                                .d(
+                                                                                                        "EventFormDialog",
+                                                                                                        "Time picker selected: ${timePickerState.hour}:${timePickerState.minute}"
+                                                                                                )
+                                                                                        android.util
+                                                                                                .Log
+                                                                                                .d(
+                                                                                                        "EventFormDialog",
+                                                                                                        "New time created: ${newTime}"
+                                                                                                )
+                                                                                        android.util
+                                                                                                .Log
+                                                                                                .d(
+                                                                                                        "EventFormDialog",
+                                                                                                        "New time formatted: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(newTime)}"
+                                                                                                )
 
                                                                                         eventViewModel
-                                                                                        .updateFormData(
-                                                                                                formData.copy(
-                                                                                                        checkInTime =
-                                                                                                                newTime
+                                                                                                .updateFormData(
+                                                                                                        formData.copy(
+                                                                                                                checkInTime =
+                                                                                                                        newTime
+                                                                                                        )
                                                                                                 )
-                                                                                        )
-                                                                                showTimePicker =
-                                                                                        false
-                                                                        },
-                                                                        colors =
-                                                                                ButtonDefaults
-                                                                                        .textButtonColors(
-                                                                                                contentColor =
-                                                                                                        MaterialTheme
-                                                                                                                .colorScheme
-                                                                                                                .primary
-                                                                        )
-                                                                ) { Text("OK") }
+                                                                                        showTimePicker =
+                                                                                                false
+                                                                                },
+                                                                                colors =
+                                                                                        ButtonDefaults
+                                                                                                .textButtonColors(
+                                                                                                        contentColor =
+                                                                                                                MaterialTheme
+                                                                                                                        .colorScheme
+                                                                                                                        .primary
+                                                                                                )
+                                                                        ) { Text("OK") }
                                                                 },
                                                                 dismissButton = {
                                                                         TextButton(
@@ -694,7 +742,7 @@ fun EventFormDialog(
                                                                                                                 MaterialTheme
                                                                                                                         .colorScheme
                                                                                                                         .onSurfaceVariant
-                                                                                )
+                                                                                                )
                                                                         ) { Text("Cancel") }
                                                                 },
                                                                 containerColor =
@@ -710,89 +758,27 @@ fun EventFormDialog(
                                                 }
                                         }
 
-                                        // Match Selection
-                                        EventFormSection(title = "Match") {
-                                                // State to track whether "Live" or "Custom" mode is
-                                                // selected
-                                                // true for Live, false for Custom
-                                                var isLiveMatchMode by
-                                                        remember(
-                                                                uiState.availableMatches,
-                                                                formData.selectedMatch
-                                                        ) {
-                                                                mutableStateOf(
-                                                                        // If editing and has a selected match, check if it's a live match
-                                                                        formData.selectedMatch?.let { match ->
-                                                                                // Custom matches have "Custom Match" as round, live matches have actual round numbers
-                                                                                match.round != "Custom Match" && 
-                                                                                uiState.availableMatches.isNotEmpty()
-                                                                        } ?: uiState.availableMatches.isNotEmpty()
-                                                                )
-                                                }
+                                        // League Selection
+                                        var selectedLeague by remember {
+                                                mutableStateOf(
+                                                        formData.selectedMatch?.competition
+                                                                ?.ifEmpty { "AFL" }
+                                                                ?: "AFL"
+                                                )
+                                        }
 
-                                                val availableTeams = uiState.availableTeams
-
-                                                var selectedHomeTeam by
-                                                        remember(
-                                                                availableTeams,
-                                                                formData.selectedMatch
-                                                        ) {
-                                                                mutableStateOf<Team?>(
-                                                                        // Initialize with team from
-                                                                        // selected match if
-                                                                        // available
-                                                                        formData.selectedMatch
-                                                                                ?.homeTeam?.let {
-                                                                                teamName ->
-                                                        availableTeams
-                                                                                        .find {
-                                                                                                it.name ==
-                                                                                                        teamName
-                                                                                        }
-                                                                        }
-                                                                )
-                                                        }
-                                                var selectedAwayTeam by
-                                                        remember(
-                                                                availableTeams,
-                                                                formData.selectedMatch
-                                                        ) {
-                                                                mutableStateOf<Team?>(
-                                                                        // Initialize with team from
-                                                                        // selected match if
-                                                                        // available
-                                                                        formData.selectedMatch
-                                                                                ?.awayTeam?.let {
-                                                                                teamName ->
-                                                                                availableTeams
-                                                                                        .find {
-                                                                                                it.name ==
-                                                                                                        teamName
-                                                                                        }
-                                                                        }
-                                                                )
-                                                }
-
-                                                LaunchedEffect(uiState.availableMatches) {
-                                                        if (uiState.availableMatches.isEmpty()) {
-                                                                isLiveMatchMode = false
-                                                        }
-                                                }
-
+                                        EventFormSection(title = "League") {
                                                 Row(
                                                         modifier = Modifier.fillMaxWidth(),
                                                         horizontalArrangement =
-                                                                Arrangement.spacedBy(
-                                                                16.dp
-                                                        ) // Add space between buttons
+                                                                Arrangement.spacedBy(8.dp)
                                                 ) {
-                                                        // --- Live Button ---
-                                                        if (isLiveMatchMode) {
-                                                                // Selected state: Filled Button
+                                                        // AFL Button
+                                                        if (selectedLeague == "AFL") {
                                                                 Button(
                                                                         onClick = {
-                                                                                isLiveMatchMode =
-                                                                                        true
+                                                                                selectedLeague =
+                                                                                        "AFL"
                                                                         },
                                                                         colors =
                                                                                 ButtonDefaults
@@ -800,7 +786,7 @@ fun EventFormDialog(
                                                                                                 containerColor =
                                                                                                         MaterialTheme
                                                                                                                 .colorScheme
-                                                                                                                .primary, // Or your orange Color(0xFFFFA500)
+                                                                                                                .primary,
                                                                                                 contentColor =
                                                                                                         MaterialTheme
                                                                                                                 .colorScheme
@@ -808,13 +794,32 @@ fun EventFormDialog(
                                                                                         ),
                                                                         modifier =
                                                                                 Modifier.weight(1f)
-                                                                ) { Text("Live") }
+                                                                ) {
+                                                                        Image(
+                                                                                painter =
+                                                                                        painterResource(
+                                                                                                id =
+                                                                                                        R.drawable
+                                                                                                                .league_afl
+                                                                                        ),
+                                                                                contentDescription =
+                                                                                        "AFL",
+                                                                                modifier =
+                                                                                        Modifier.size(
+                                                                                                        24.dp
+                                                                                                )
+                                                                                                .padding(
+                                                                                                        end =
+                                                                                                                8.dp
+                                                                                                )
+                                                                        )
+                                                                        Text("AFL")
+                                                                }
                                                         } else {
-                                                                // Unselected state: Outlined Button
                                                                 OutlinedButton(
                                                                         onClick = {
-                                                                                isLiveMatchMode =
-                                                                                        true
+                                                                                selectedLeague =
+                                                                                        "AFL"
                                                                         },
                                                                         colors =
                                                                                 ButtonDefaults
@@ -822,28 +827,46 @@ fun EventFormDialog(
                                                                                                 contentColor =
                                                                                                         MaterialTheme
                                                                                                                 .colorScheme
-                                                                                                                .primary // Text color for outlined button
+                                                                                                                .primary
                                                                                         ),
                                                                         border =
                                                                                 BorderStroke(
-                                                                                1.dp,
+                                                                                        1.dp,
                                                                                         MaterialTheme
                                                                                                 .colorScheme
                                                                                                 .primary
-                                                                        ), // Outline color
+                                                                                ),
                                                                         modifier =
                                                                                 Modifier.weight(1f)
-                                                                ) { Text("Live") }
+                                                                ) {
+                                                                        Image(
+                                                                                painter =
+                                                                                        painterResource(
+                                                                                                id =
+                                                                                                        R.drawable
+                                                                                                                .league_afl
+                                                                                        ),
+                                                                                contentDescription =
+                                                                                        "AFL",
+                                                                                modifier =
+                                                                                        Modifier.size(
+                                                                                                        24.dp
+                                                                                                )
+                                                                                                .padding(
+                                                                                                        end =
+                                                                                                                8.dp
+                                                                                                )
+                                                                        )
+                                                                        Text("AFL")
+                                                                }
                                                         }
 
-                                                        // --- Custom Button ---
-                                                        if (!isLiveMatchMode
-                                                        ) { // Note the negation here
-                                                                // Selected state: Filled Button
+                                                        // F1 Button
+                                                        if (selectedLeague == "F1") {
                                                                 Button(
                                                                         onClick = {
-                                                                                isLiveMatchMode =
-                                                                                        false
+                                                                                selectedLeague =
+                                                                                        "F1"
                                                                         },
                                                                         colors =
                                                                                 ButtonDefaults
@@ -851,7 +874,7 @@ fun EventFormDialog(
                                                                                                 containerColor =
                                                                                                         MaterialTheme
                                                                                                                 .colorScheme
-                                                                                                                .primary, // Or your desired selected color
+                                                                                                                .primary,
                                                                                                 contentColor =
                                                                                                         MaterialTheme
                                                                                                                 .colorScheme
@@ -859,13 +882,32 @@ fun EventFormDialog(
                                                                                         ),
                                                                         modifier =
                                                                                 Modifier.weight(1f)
-                                                                ) { Text("Custom") }
+                                                                ) {
+                                                                        Image(
+                                                                                painter =
+                                                                                        painterResource(
+                                                                                                id =
+                                                                                                        R.drawable
+                                                                                                                .league_f1
+                                                                                        ),
+                                                                                contentDescription =
+                                                                                        "F1",
+                                                                                modifier =
+                                                                                        Modifier.size(
+                                                                                                        24.dp
+                                                                                                )
+                                                                                                .padding(
+                                                                                                        end =
+                                                                                                                8.dp
+                                                                                                )
+                                                                        )
+                                                                        Text("F1")
+                                                                }
                                                         } else {
-                                                                // Unselected state: Outlined Button
                                                                 OutlinedButton(
                                                                         onClick = {
-                                                                                isLiveMatchMode =
-                                                                                        false
+                                                                                selectedLeague =
+                                                                                        "F1"
                                                                         },
                                                                         colors =
                                                                                 ButtonDefaults
@@ -873,292 +915,775 @@ fun EventFormDialog(
                                                                                                 contentColor =
                                                                                                         MaterialTheme
                                                                                                                 .colorScheme
-                                                                                                                .primary // Text color
+                                                                                                                .primary
                                                                                         ),
                                                                         border =
                                                                                 BorderStroke(
-                                                                                1.dp,
+                                                                                        1.dp,
                                                                                         MaterialTheme
                                                                                                 .colorScheme
                                                                                                 .primary
-                                                                        ), // Outline color
+                                                                                ),
                                                                         modifier =
                                                                                 Modifier.weight(1f)
-                                                                ) { Text("Custom") }
+                                                                ) {
+                                                                        Image(
+                                                                                painter =
+                                                                                        painterResource(
+                                                                                                id =
+                                                                                                        R.drawable
+                                                                                                                .league_f1
+                                                                                        ),
+                                                                                contentDescription =
+                                                                                        "F1",
+                                                                                modifier =
+                                                                                        Modifier.size(
+                                                                                                        24.dp
+                                                                                                )
+                                                                                                .padding(
+                                                                                                        end =
+                                                                                                                8.dp
+                                                                                                )
+                                                                        )
+                                                                        Text("F1")
+                                                                }
                                                         }
                                                 }
-                                                if (isLiveMatchMode) {
-                                                        // --- UI for LIVE Match Mode ---
-                                                        if (uiState.availableMatches.isNotEmpty()) {
-                                                                var expanded by remember {
-                                                                        mutableStateOf(false)
-                                                                }
+                                        }
 
-                                                                ExposedDropdownMenuBox(
-                                                                        expanded = expanded,
-                                                                        onExpandedChange = {
-                                                                                expanded = !expanded
+                                        // Match Selection (AFL only) or Grand Prix Selection (F1)
+                                        // Use the league selected in the UI, not from formData
+                                        val currentSelectedLeague = selectedLeague
+
+                                        // AFL-specific variables (moved outside else block for button validation access)
+                                        var isLiveMatchMode by remember(
+                                                uiState.availableMatches,
+                                                formData.selectedMatch
+                                        ) {
+                                                mutableStateOf(
+                                                        formData.selectedMatch
+                                                                ?.let { match ->
+                                                                        match.round != "Custom Match" &&
+                                                                                uiState.availableMatches.isNotEmpty()
+                                                                }
+                                                                ?: uiState.availableMatches.isNotEmpty()
+                                                )
+                                        }
+
+                                        val availableTeams = uiState.availableTeams
+
+                                        var selectedHomeTeam by remember(
+                                                availableTeams,
+                                                formData.selectedMatch
+                                        ) {
+                                                mutableStateOf<Team?>(
+                                                        formData.selectedMatch
+                                                                ?.homeTeam
+                                                                ?.let { teamName ->
+                                                                        availableTeams.find { it.name == teamName }
+                                                                }
+                                                )
+                                        }
+
+                                        var selectedAwayTeam by remember(
+                                                availableTeams,
+                                                formData.selectedMatch
+                                        ) {
+                                                mutableStateOf<Team?>(
+                                                        formData.selectedMatch
+                                                                ?.awayTeam
+                                                                ?.let { teamName ->
+                                                                        availableTeams.find { it.name == teamName }
+                                                                }
+                                                )
+                                        }
+
+                                        LaunchedEffect(uiState.availableMatches) {
+                                                if (uiState.availableMatches.isEmpty()) {
+                                                        isLiveMatchMode = false
+                                                }
+                                        }
+
+                                        if (currentSelectedLeague == "F1") {
+                                                // F1 Grand Prix Selection
+                                                EventFormSection(title = "Grand Prix") {
+                                                        var selectedGrandPrix by remember {
+                                                                mutableStateOf(
+                                                                        formData.selectedMatch
+                                                                                ?.venue
+                                                                                ?: ""
+                                                                )
+                                                        }
+                                                        var expanded by remember {
+                                                                mutableStateOf(false)
+                                                        }
+
+                                                        ExposedDropdownMenuBox(
+                                                                expanded = expanded,
+                                                                onExpandedChange = {
+                                                                        expanded = !expanded
+                                                                },
+                                                                modifier = Modifier.fillMaxWidth()
+                                                        ) {
+                                                                OutlinedTextField(
+                                                                        value =
+                                                                                selectedGrandPrix
+                                                                                        .ifEmpty {
+                                                                                                "Select a Grand Prix *"
+                                                                                        },
+                                                                        onValueChange = {},
+                                                                        readOnly = true,
+                                                                        label = {
+                                                                                Text("Grand Prix *")
+                                                                        },
+                                                                        trailingIcon = {
+                                                                                ExposedDropdownMenuDefaults
+                                                                                        .TrailingIcon(
+                                                                                                expanded =
+                                                                                                        expanded
+                                                                                        )
                                                                         },
                                                                         modifier =
                                                                                 Modifier.fillMaxWidth()
-                                                                ) {
-                                                                        OutlinedTextField(
-                                                                                value =
-                                                                                        formData.selectedMatch // <<< THIS IS THE KEY CHANGE
-                                                                                                ?.let {
-                                                                                                        currentSelectedMatch
-                                                                                                        -> // If a match is selected in formData...
-                                                                                                val home =
-                                                                                                                currentSelectedMatch
-                                                                                                                        .homeTeam
-                                                                                                                ?: "TBD"
-                                                                                                val away =
-                                                                                                                currentSelectedMatch
-                                                                                                                        .awayTeam
-                                                                                                                ?: "TBD"
-                                                                                                val venueInfo =
-                                                                                                                currentSelectedMatch
-                                                                                                                        .venue
-                                                                                                                        ?.let {
-                                                                                                                                " - $it"
-                                                                                                                        }
-                                                                                                                ?: ""
-                                                                                                "$home vs $away$venueInfo" // ...display its details.
-                                                                                        }
-                                                                                        ?: "Select a live match *", // Default if formData.selectedMatch is null
-                                                                                onValueChange = {
-                                                                                }, // Not directly
-                                                                                // editable
-                                                                                readOnly = true,
-                                                                                label = {
-                                                                                        Text(
-                                                                                                "Selected Live Match *"
-                                                                                        )
-                                                                                }, // Updated label
-                                                                                trailingIcon = {
-                                                                                        ExposedDropdownMenuDefaults
-                                                                                                .TrailingIcon(
-                                                                                                        expanded =
-                                                                                                                expanded
-                                                                                                )
-                                                                                },
-                                                                                modifier =
-                                                                                        Modifier.fillMaxWidth()
                                                                                         .menuAnchor()
-                                                                        )
+                                                                )
 
-                                                                        ExposedDropdownMenu(
-                                                                                expanded = expanded,
-                                                                                onDismissRequest = {
-                                                                                        expanded =
-                                                                                                false
-                                                                                }
-                                                                        ) {
-                                                                                if (uiState.isLoadingMatches &&
-                                                                                                uiState.availableMatches
-                                                                                                        .isEmpty()
-                                                                                ) {
+                                                                ExposedDropdownMenu(
+                                                                        expanded = expanded,
+                                                                        onDismissRequest = {
+                                                                                expanded = false
+                                                                        }
+                                                                ) {
+                                                                        com.example
+                                                                                .mobilecomputingassignment
+                                                                                .data.constants
+                                                                                .TeamConstants
+                                                                                .F1_GRAND_PRIX
+                                                                                .forEach { grandPrix
+                                                                                        ->
                                                                                         DropdownMenuItem(
                                                                                                 onClick = {
-                                                                                                },
-                                                                                                enabled =
-                                                                                                        false,
-                                                                                                text = {
-                                                                                                        Text(
-                                                                                                                "Still loading..."
-                                                                                                        )
-                                                                                                }
-                                                                                        )
-                                                                                }
-                                                                                uiState.availableMatches
-                                                                                        .forEach {
-                                                                                                matchInList
-                                                                                                ->
-                                                                                        DropdownMenuItem(
-                                                                                                onClick = {
-                                                                                                                eventViewModel
-                                                                                                                        .selectMatch(
-                                                                                                                matchInList
-                                                                                                        )
+                                                                                                        selectedGrandPrix =
+                                                                                                                grandPrix
+                                                                                                        // Create F1 match details
+                                                                                                        val calendar =
+                                                                                                                Calendar.getInstance()
+                                                                                                        calendar.time =
+                                                                                                                formData.date
+                                                                                                        val season =
+                                                                                                                calendar.get(
+                                                                                                                        Calendar.YEAR
+                                                                                                                )
+
+                                                                                                        val f1Match =
+                                                                                                                com.example
+                                                                                                                        .mobilecomputingassignment
+                                                                                                                        .domain
+                                                                                                                        .models
+                                                                                                                        .MatchDetails(
+                                                                                                                                id =
+                                                                                                                                        "f1_${System.currentTimeMillis()}",
+                                                                                                                                homeTeam =
+                                                                                                                                        "",
+                                                                                                                                awayTeam =
+                                                                                                                                        "",
+                                                                                                                                competition =
+                                                                                                                                        "F1",
+                                                                                                                                venue =
+                                                                                                                                        grandPrix,
+                                                                                                                                matchTime =
+                                                                                                                                        formData.date,
+                                                                                                                                round =
+                                                                                                                                        grandPrix,
+                                                                                                                                season =
+                                                                                                                                        season
+                                                                                                                        )
+
+                                                                                                        eventViewModel
+                                                                                                                .selectMatch(
+                                                                                                                        f1Match
+                                                                                                                )
                                                                                                         expanded =
                                                                                                                 false
                                                                                                 },
                                                                                                 text = {
                                                                                                         Text(
-                                                                                                                "${matchInList.homeTeam ?: "TBD"} vs ${matchInList.awayTeam ?: "TBD"}"
+                                                                                                                grandPrix
                                                                                                         )
                                                                                                 }
                                                                                         )
                                                                                 }
-                                                                        }
                                                                 }
-                                                                formData.selectedMatch?.let {
-                                                                        selected ->
-                                                                        Spacer(
-                                                                                modifier =
-                                                                                        Modifier.height(
+                                                        }
+
+                                                        // Show F1 logo if a Grand Prix is selected
+                                                        if (selectedGrandPrix.isNotEmpty()) {
+                                                                Spacer(
+                                                                        modifier =
+                                                                                Modifier.height(
                                                                                         12.dp
                                                                                 )
-                                                                        )
-
-                                                                        TeamVsTeamDisplay(
-                                                                                homeTeamName =
-                                                                                        selected.homeTeam,
-                                                                                awayTeamName =
-                                                                                        selected.awayTeam
-                                                                        )
-                                                                }
-                                                        } else { // No matches available and not
-                                                                // loading
-                                                                Text(
-                                                                        text =
-                                                                                "There are no live matches available for the selected date. Please select another day or create a custom match.",
-                                                                        style =
-                                                                                MaterialTheme
-                                                                                        .typography
-                                                                                        .bodyMedium,
-                                                                        color =
-                                                                                MaterialTheme
-                                                                                        .colorScheme
-                                                                                        .error,
-                                                                        textAlign =
-                                                                                TextAlign.Center,
-                                                                        modifier =
-                                                                                Modifier.fillMaxWidth()
-                                                                                .padding(
-                                                                                                horizontal =
-                                                                                                        16.dp,
-                                                                                                vertical =
-                                                                                                        8.dp
-                                                                                )
                                                                 )
-                                                        }
-                                                } // --- Custom Matches ---
-                                                else {
-
-                                                        // Add this LaunchedEffect to load teams
-                                                        // when entering custom mode
-                                                        LaunchedEffect(Unit) {
-                                                                eventViewModel
-                                                                        .loadAflTeams() // You need
-                                                                // to make
-                                                                // this
-                                                                // method
-                                                                // public
-                                                        }
-
-                                                        var expandedHomeTeam by remember {
-                                                                mutableStateOf(false)
-                                                        }
-                                                        var expandedAwayTeam by remember {
-                                                                mutableStateOf(false)
-                                                        }
-
-                                                        Column(
-                                                                modifier =
-                                                                        Modifier.fillMaxWidth()
-                                                                                .padding(
-                                                                                        vertical =
-                                                                                                8.dp
-                                                                                ),
-                                                                horizontalAlignment =
-                                                                        Alignment
-                                                                                .CenterHorizontally,
-                                                                verticalArrangement =
-                                                                        Arrangement.spacedBy(12.dp)
-                                                        ) {
                                                                 Row(
                                                                         modifier =
                                                                                 Modifier.fillMaxWidth(),
                                                                         horizontalArrangement =
-                                                                                Arrangement
-                                                                                        .spacedBy(
-                                                                                                16.dp
-                                                                                        ), // gap
-                                                                        // between fields
+                                                                                Arrangement.Center,
                                                                         verticalAlignment =
-                                                                                Alignment.Top
+                                                                                Alignment
+                                                                                        .CenterVertically
                                                                 ) {
-                                                                        // --- Home Team Dropdown
-                                                                        // ---
-                                                                        Column(
+                                                                        Image(
+                                                                                painter =
+                                                                                        painterResource(
+                                                                                                id =
+                                                                                                        R.drawable
+                                                                                                                .league_f1
+                                                                                        ),
+                                                                                contentDescription =
+                                                                                        "F1",
+                                                                                modifier =
+                                                                                        Modifier.size(
+                                                                                                80.dp
+                                                                                        )
+                                                                        )
+                                                                }
+                                                        }
+                                                }
+                                        } else {
+                                                // AFL Match Selection
+
+                                                EventFormSection(title = "Match") {
+
+                                                        Row(
+                                                                modifier = Modifier.fillMaxWidth(),
+                                                                horizontalArrangement =
+                                                                        Arrangement.spacedBy(
+                                                                                16.dp
+                                                                        ) // Add space between
+                                                                // buttons
+                                                                ) {
+                                                                // --- Live Button ---
+                                                                if (isLiveMatchMode) {
+                                                                        // Selected state: Filled
+                                                                        // Button
+                                                                        Button(
+                                                                                onClick = {
+                                                                                        isLiveMatchMode =
+                                                                                                true
+                                                                                },
+                                                                                colors =
+                                                                                        ButtonDefaults
+                                                                                                .buttonColors(
+                                                                                                        containerColor =
+                                                                                                                MaterialTheme
+                                                                                                                        .colorScheme
+                                                                                                                        .primary, // Or your orange Color(0xFFFFA500)
+                                                                                                        contentColor =
+                                                                                                                MaterialTheme
+                                                                                                                        .colorScheme
+                                                                                                                        .onPrimary
+                                                                                                ),
                                                                                 modifier =
                                                                                         Modifier.weight(
                                                                                                 1f
                                                                                         )
-                                                                        ) {
-                                                                                Text(
-                                                                                        text =
-                                                                                                "Home Team *",
-                                                                                        style =
+                                                                        ) { Text("Live") }
+                                                                } else {
+                                                                        // Unselected state:
+                                                                        // Outlined Button
+                                                                        OutlinedButton(
+                                                                                onClick = {
+                                                                                        isLiveMatchMode =
+                                                                                                true
+                                                                                },
+                                                                                colors =
+                                                                                        ButtonDefaults
+                                                                                                .outlinedButtonColors(
+                                                                                                        contentColor =
+                                                                                                                MaterialTheme
+                                                                                                                        .colorScheme
+                                                                                                                        .primary // Text color for outlined button
+                                                                                                ),
+                                                                                border =
+                                                                                        BorderStroke(
+                                                                                                1.dp,
                                                                                                 MaterialTheme
-                                                                                                        .typography
-                                                                                                        .titleMedium,
-                                                                                        fontWeight =
-                                                                                                FontWeight
-                                                                                                        .Bold,
-                                                                                        modifier =
-                                                                                                Modifier.padding(
-                                                                                                        bottom =
-                                                                                                                8.dp
+                                                                                                        .colorScheme
+                                                                                                        .primary
+                                                                                        ), // Outline color
+                                                                                modifier =
+                                                                                        Modifier.weight(
+                                                                                                1f
                                                                                         )
+                                                                        ) { Text("Live") }
+                                                                }
+
+                                                                // --- Custom Button ---
+                                                                if (!isLiveMatchMode
+                                                                ) { // Note the negation here
+                                                                        // Selected state: Filled
+                                                                        // Button
+                                                                        Button(
+                                                                                onClick = {
+                                                                                        isLiveMatchMode =
+                                                                                                false
+                                                                                },
+                                                                                colors =
+                                                                                        ButtonDefaults
+                                                                                                .buttonColors(
+                                                                                                        containerColor =
+                                                                                                                MaterialTheme
+                                                                                                                        .colorScheme
+                                                                                                                        .primary, // Or your desired selected color
+                                                                                                        contentColor =
+                                                                                                                MaterialTheme
+                                                                                                                        .colorScheme
+                                                                                                                        .onPrimary
+                                                                                                ),
+                                                                                modifier =
+                                                                                        Modifier.weight(
+                                                                                                1f
+                                                                                        )
+                                                                        ) { Text("Custom") }
+                                                                } else {
+                                                                        // Unselected state:
+                                                                        // Outlined Button
+                                                                        OutlinedButton(
+                                                                                onClick = {
+                                                                                        isLiveMatchMode =
+                                                                                                false
+                                                                                },
+                                                                                colors =
+                                                                                        ButtonDefaults
+                                                                                                .outlinedButtonColors(
+                                                                                                        contentColor =
+                                                                                                                MaterialTheme
+                                                                                                                        .colorScheme
+                                                                                                                        .primary // Text color
+                                                                                                ),
+                                                                                border =
+                                                                                        BorderStroke(
+                                                                                                1.dp,
+                                                                                                MaterialTheme
+                                                                                                        .colorScheme
+                                                                                                        .primary
+                                                                                        ), // Outline color
+                                                                                modifier =
+                                                                                        Modifier.weight(
+                                                                                                1f
+                                                                                        )
+                                                                        ) { Text("Custom") }
+                                                                }
+                                                        }
+                                                        if (isLiveMatchMode) {
+                                                                // --- UI for LIVE Match Mode ---
+                                                                if (uiState.availableMatches
+                                                                                .isNotEmpty()
+                                                                ) {
+                                                                        var expanded by remember {
+                                                                                mutableStateOf(
+                                                                                        false
+                                                                                )
+                                                                        }
+
+                                                                        ExposedDropdownMenuBox(
+                                                                                expanded = expanded,
+                                                                                onExpandedChange = {
+                                                                                        expanded =
+                                                                                                !expanded
+                                                                                },
+                                                                                modifier =
+                                                                                        Modifier.fillMaxWidth()
+                                                                        ) {
+                                                                                OutlinedTextField(
+                                                                                        value =
+                                                                                                formData.selectedMatch // <<< THIS IS THE KEY CHANGE
+                                                                                                        ?.let {
+                                                                                                                currentSelectedMatch
+                                                                                                                -> // If a match is selected in formData...
+                                                                                                                val home =
+                                                                                                                        currentSelectedMatch
+                                                                                                                                .homeTeam
+                                                                                                                                ?: "TBD"
+                                                                                                                val away =
+                                                                                                                        currentSelectedMatch
+                                                                                                                                .awayTeam
+                                                                                                                                ?: "TBD"
+                                                                                                                val venueInfo =
+                                                                                                                        currentSelectedMatch
+                                                                                                                                .venue
+                                                                                                                                ?.let {
+                                                                                                                                        " - $it"
+                                                                                                                                }
+                                                                                                                                ?: ""
+                                                                                                                "$home vs $away$venueInfo" // ...display its details.
+                                                                                                        }
+                                                                                                        ?: "Select a live match *", // Default if formData.selectedMatch is null
+                                                                                        onValueChange = {
+                                                                                        }, // Not
+                                                                                        // directly
+                                                                                        // editable
+                                                                                        readOnly =
+                                                                                                true,
+                                                                                        label = {
+                                                                                                Text(
+                                                                                                        "Selected Live Match *"
+                                                                                                )
+                                                                                        }, // Updated label
+                                                                                        trailingIcon = {
+                                                                                                ExposedDropdownMenuDefaults
+                                                                                                        .TrailingIcon(
+                                                                                                                expanded =
+                                                                                                                        expanded
+                                                                                                        )
+                                                                                        },
+                                                                                        modifier =
+                                                                                                Modifier.fillMaxWidth()
+                                                                                                        .menuAnchor()
                                                                                 )
 
-                                                                                ExposedDropdownMenuBox(
+                                                                                ExposedDropdownMenu(
                                                                                         expanded =
-                                                                                                expandedHomeTeam,
-                                                                                        onExpandedChange = {
-                                                                                                expandedHomeTeam =
-                                                                                                        !expandedHomeTeam
+                                                                                                expanded,
+                                                                                        onDismissRequest = {
+                                                                                                expanded =
+                                                                                                        false
                                                                                         }
                                                                                 ) {
-                                                                                        OutlinedTextField(
-                                                                                                value =
-                                                                                                        selectedHomeTeam
-                                                                                                                ?.name
-                                                                                                        ?: "Home team",
-                                                                                                onValueChange = {
-                                                                                                },
-                                                                                                readOnly =
-                                                                                                        true,
-                                                                                                trailingIcon = {
-                                                                                                        ExposedDropdownMenuDefaults
-                                                                                                                .TrailingIcon(
-                                                                                                                expandedHomeTeam
-                                                                                                        )
-                                                                                                },
-                                                                                                modifier =
-                                                                                                        Modifier.fillMaxWidth()
-                                                                                                        .menuAnchor()
-                                                                                        )
-
-                                                                                        ExposedDropdownMenu(
-                                                                                                expanded =
-                                                                                                        expandedHomeTeam,
-                                                                                                onDismissRequest = {
-                                                                                                        expandedHomeTeam =
-                                                                                                                false
-                                                                                                }
-                                                                                        ) {
-                                                                                                if (availableTeams
+                                                                                        if (uiState.isLoadingMatches &&
+                                                                                                        uiState.availableMatches
                                                                                                                 .isEmpty()
-                                                                                                ) {
+                                                                                        ) {
+                                                                                                DropdownMenuItem(
+                                                                                                        onClick = {
+                                                                                                        },
+                                                                                                        enabled =
+                                                                                                                false,
+                                                                                                        text = {
+                                                                                                                Text(
+                                                                                                                        "Still loading..."
+                                                                                                                )
+                                                                                                        }
+                                                                                                )
+                                                                                        }
+                                                                                        uiState.availableMatches
+                                                                                                .forEach {
+                                                                                                        matchInList
+                                                                                                        ->
                                                                                                         DropdownMenuItem(
+                                                                                                                onClick = {
+                                                                                                                        eventViewModel
+                                                                                                                                .selectMatch(
+                                                                                                                                        matchInList
+                                                                                                                                )
+                                                                                                                        expanded =
+                                                                                                                                false
+                                                                                                                },
                                                                                                                 text = {
                                                                                                                         Text(
-                                                                                                                                "No teams available"
+                                                                                                                                "${matchInList.homeTeam ?: "TBD"} vs ${matchInList.awayTeam ?: "TBD"}"
                                                                                                                         )
-                                                                                                                },
-                                                                                                                onClick = {
                                                                                                                 }
                                                                                                         )
-                                                                                                } else {
+                                                                                                }
+                                                                                }
+                                                                        }
+                                                                        formData.selectedMatch
+                                                                                ?.let { selected ->
+                                                                                        Spacer(
+                                                                                                modifier =
+                                                                                                        Modifier.height(
+                                                                                                                12.dp
+                                                                                                        )
+                                                                                        )
+
+                                                                                        TeamVsTeamDisplay(
+                                                                                                homeTeamName =
+                                                                                                        selected.homeTeam,
+                                                                                                awayTeamName =
+                                                                                                        selected.awayTeam
+                                                                                        )
+                                                                                }
+                                                                } else { // No matches available and
+                                                                        // not
+                                                                        // loading
+                                                                        Text(
+                                                                                text =
+                                                                                        "There are no live matches available for the selected date. Please select another day or create a custom match.",
+                                                                                style =
+                                                                                        MaterialTheme
+                                                                                                .typography
+                                                                                                .bodyMedium,
+                                                                                color =
+                                                                                        MaterialTheme
+                                                                                                .colorScheme
+                                                                                                .error,
+                                                                                textAlign =
+                                                                                        TextAlign
+                                                                                                .Center,
+                                                                                modifier =
+                                                                                        Modifier.fillMaxWidth()
+                                                                                                .padding(
+                                                                                                        horizontal =
+                                                                                                                16.dp,
+                                                                                                        vertical =
+                                                                                                                8.dp
+                                                                                                )
+                                                                        )
+                                                                }
+                                                        } // --- Custom Matches ---
+                                                        else {
+
+                                                                // Add this LaunchedEffect to load
+                                                                // teams
+                                                                // when entering custom mode
+                                                                LaunchedEffect(Unit) {
+                                                                        eventViewModel
+                                                                                .loadAflTeams() // You need
+                                                                        // to make
+                                                                        // this
+                                                                        // method
+                                                                        // public
+                                                                }
+
+                                                                var expandedHomeTeam by remember {
+                                                                        mutableStateOf(false)
+                                                                }
+                                                                var expandedAwayTeam by remember {
+                                                                        mutableStateOf(false)
+                                                                }
+
+                                                                Column(
+                                                                        modifier =
+                                                                                Modifier.fillMaxWidth()
+                                                                                        .padding(
+                                                                                                vertical =
+                                                                                                        8.dp
+                                                                                        ),
+                                                                        horizontalAlignment =
+                                                                                Alignment
+                                                                                        .CenterHorizontally,
+                                                                        verticalArrangement =
+                                                                                Arrangement
+                                                                                        .spacedBy(
+                                                                                                12.dp
+                                                                                        )
+                                                                ) {
+                                                                        Row(
+                                                                                modifier =
+                                                                                        Modifier.fillMaxWidth(),
+                                                                                horizontalArrangement =
+                                                                                        Arrangement
+                                                                                                .spacedBy(
+                                                                                                        16.dp
+                                                                                                ), // gap
+                                                                                // between fields
+                                                                                verticalAlignment =
+                                                                                        Alignment
+                                                                                                .Top
+                                                                        ) {
+                                                                                // --- Home Team
+                                                                                // Dropdown
+                                                                                // ---
+                                                                                Column(
+                                                                                        modifier =
+                                                                                                Modifier.weight(
+                                                                                                        1f
+                                                                                                )
+                                                                                ) {
+                                                                                        Text(
+                                                                                                text =
+                                                                                                        "Home Team *",
+                                                                                                style =
+                                                                                                        MaterialTheme
+                                                                                                                .typography
+                                                                                                                .titleMedium,
+                                                                                                fontWeight =
+                                                                                                        FontWeight
+                                                                                                                .Bold,
+                                                                                                modifier =
+                                                                                                        Modifier.padding(
+                                                                                                                bottom =
+                                                                                                                        8.dp
+                                                                                                        )
+                                                                                        )
+
+                                                                                        ExposedDropdownMenuBox(
+                                                                                                expanded =
+                                                                                                        expandedHomeTeam,
+                                                                                                onExpandedChange = {
+                                                                                                        expandedHomeTeam =
+                                                                                                                !expandedHomeTeam
+                                                                                                }
+                                                                                        ) {
+                                                                                                OutlinedTextField(
+                                                                                                        value =
+                                                                                                                selectedHomeTeam
+                                                                                                                        ?.name
+                                                                                                                        ?: "Home team",
+                                                                                                        onValueChange = {
+                                                                                                        },
+                                                                                                        readOnly =
+                                                                                                                true,
+                                                                                                        trailingIcon = {
+                                                                                                                ExposedDropdownMenuDefaults
+                                                                                                                        .TrailingIcon(
+                                                                                                                                expandedHomeTeam
+                                                                                                                        )
+                                                                                                        },
+                                                                                                        modifier =
+                                                                                                                Modifier.fillMaxWidth()
+                                                                                                                        .menuAnchor()
+                                                                                                )
+
+                                                                                                ExposedDropdownMenu(
+                                                                                                        expanded =
+                                                                                                                expandedHomeTeam,
+                                                                                                        onDismissRequest = {
+                                                                                                                expandedHomeTeam =
+                                                                                                                        false
+                                                                                                        }
+                                                                                                ) {
+                                                                                                        if (availableTeams
+                                                                                                                        .isEmpty()
+                                                                                                        ) {
+                                                                                                                DropdownMenuItem(
+                                                                                                                        text = {
+                                                                                                                                Text(
+                                                                                                                                        "No teams available"
+                                                                                                                                )
+                                                                                                                        },
+                                                                                                                        onClick = {
+                                                                                                                        }
+                                                                                                                )
+                                                                                                        } else {
+                                                                                                                availableTeams
+                                                                                                                        .forEach {
+                                                                                                                                team
+                                                                                                                                ->
+                                                                                                                                DropdownMenuItem(
+                                                                                                                                        text = {
+                                                                                                                                                Row(
+                                                                                                                                                        verticalAlignment =
+                                                                                                                                                                Alignment
+                                                                                                                                                                        .CenterVertically
+                                                                                                                                                ) {
+                                                                                                                                                        team.localLogoRes
+                                                                                                                                                                ?.let {
+                                                                                                                                                                        logoRes
+                                                                                                                                                                        ->
+                                                                                                                                                                        Image(
+                                                                                                                                                                                painter =
+                                                                                                                                                                                        painterResource(
+                                                                                                                                                                                                id =
+                                                                                                                                                                                                        logoRes
+                                                                                                                                                                                        ),
+                                                                                                                                                                                contentDescription =
+                                                                                                                                                                                        team.name,
+                                                                                                                                                                                modifier =
+                                                                                                                                                                                        Modifier.size(
+                                                                                                                                                                                                24.dp
+                                                                                                                                                                                        )
+                                                                                                                                                                        )
+                                                                                                                                                                        Spacer(
+                                                                                                                                                                                modifier =
+                                                                                                                                                                                        Modifier.width(
+                                                                                                                                                                                                8.dp
+                                                                                                                                                                                        )
+                                                                                                                                                                        )
+                                                                                                                                                                }
+                                                                                                                                                        Text(
+                                                                                                                                                                team.name
+                                                                                                                                                        )
+                                                                                                                                                }
+                                                                                                                                        },
+                                                                                                                                        // In the home team onClick:
+                                                                                                                                        onClick = {
+                                                                                                                                                selectedHomeTeam =
+                                                                                                                                                        team
+                                                                                                                                                expandedHomeTeam =
+                                                                                                                                                        false
+                                                                                                                                        }
+                                                                                                                                )
+                                                                                                                        }
+                                                                                                        }
+                                                                                                }
+                                                                                        }
+                                                                                }
+
+                                                                                // --- Away Team
+                                                                                // Dropdown
+                                                                                // ---
+                                                                                Column(
+                                                                                        modifier =
+                                                                                                Modifier.weight(
+                                                                                                        1f
+                                                                                                )
+                                                                                ) {
+                                                                                        Text(
+                                                                                                text =
+                                                                                                        "Away Team *",
+                                                                                                style =
+                                                                                                        MaterialTheme
+                                                                                                                .typography
+                                                                                                                .titleMedium,
+                                                                                                fontWeight =
+                                                                                                        FontWeight
+                                                                                                                .Bold,
+                                                                                                modifier =
+                                                                                                        Modifier.padding(
+                                                                                                                bottom =
+                                                                                                                        8.dp
+                                                                                                        )
+                                                                                        )
+
+                                                                                        ExposedDropdownMenuBox(
+                                                                                                expanded =
+                                                                                                        expandedAwayTeam,
+                                                                                                onExpandedChange = {
+                                                                                                        expandedAwayTeam =
+                                                                                                                !expandedAwayTeam
+                                                                                                }
+                                                                                        ) {
+                                                                                                OutlinedTextField(
+                                                                                                        value =
+                                                                                                                selectedAwayTeam
+                                                                                                                        ?.name
+                                                                                                                        ?: "Away team",
+                                                                                                        onValueChange = {
+                                                                                                        },
+                                                                                                        readOnly =
+                                                                                                                true,
+                                                                                                        trailingIcon = {
+                                                                                                                ExposedDropdownMenuDefaults
+                                                                                                                        .TrailingIcon(
+                                                                                                                                expandedAwayTeam
+                                                                                                                        )
+                                                                                                        },
+                                                                                                        modifier =
+                                                                                                                Modifier.fillMaxWidth()
+                                                                                                                        .menuAnchor()
+                                                                                                )
+
+                                                                                                ExposedDropdownMenu(
+                                                                                                        expanded =
+                                                                                                                expandedAwayTeam,
+                                                                                                        onDismissRequest = {
+                                                                                                                expandedAwayTeam =
+                                                                                                                        false
+                                                                                                        }
+                                                                                                ) {
                                                                                                         availableTeams
+                                                                                                                .filter {
+                                                                                                                        it !=
+                                                                                                                                selectedHomeTeam
+                                                                                                                }
                                                                                                                 .forEach {
                                                                                                                         team
                                                                                                                         ->
-                                                                                                                DropdownMenuItem(
-                                                                                                                        text = {
+                                                                                                                        DropdownMenuItem(
+                                                                                                                                text = {
                                                                                                                                         Row(
                                                                                                                                                 verticalAlignment =
                                                                                                                                                         Alignment
@@ -1168,7 +1693,7 @@ fun EventFormDialog(
                                                                                                                                                         ?.let {
                                                                                                                                                                 logoRes
                                                                                                                                                                 ->
-                                                                                                                                                Image(
+                                                                                                                                                                Image(
                                                                                                                                                                         painter =
                                                                                                                                                                                 painterResource(
                                                                                                                                                                                         id =
@@ -1178,193 +1703,85 @@ fun EventFormDialog(
                                                                                                                                                                                 team.name,
                                                                                                                                                                         modifier =
                                                                                                                                                                                 Modifier.size(
-                                                                                                                                                                24.dp
-                                                                                                                                                        )
-                                                                                                                                                )
-                                                                                                                                                Spacer(
+                                                                                                                                                                                        24.dp
+                                                                                                                                                                                )
+                                                                                                                                                                )
+                                                                                                                                                                Spacer(
                                                                                                                                                                         modifier =
                                                                                                                                                                                 Modifier.width(
-                                                                                                                                                                8.dp
-                                                                                                                                                        )
-                                                                                                                                                )
-                                                                                                                                        }
+                                                                                                                                                                                        8.dp
+                                                                                                                                                                                )
+                                                                                                                                                                )
+                                                                                                                                                        }
                                                                                                                                                 Text(
                                                                                                                                                         team.name
                                                                                                                                                 )
-                                                                                                                                }
-                                                                                                                        },
-                                                                                                                        // In the home team onClick:
-                                                                                                                        onClick = {
-                                                                                                                                selectedHomeTeam =
-                                                                                                                                        team
-                                                                                                                                expandedHomeTeam =
-                                                                                                                                        false
-                                                                                                                        }
-                                                                                                                )
-                                                                                                        }
-                                                                                                }
-                                                                                        }
-                                                                                }
-                                                                        }
-
-                                                                        // --- Away Team Dropdown
-                                                                        // ---
-                                                                        Column(
-                                                                                modifier =
-                                                                                        Modifier.weight(
-                                                                                                1f
-                                                                                        )
-                                                                        ) {
-                                                                                Text(
-                                                                                        text =
-                                                                                                "Away Team *",
-                                                                                        style =
-                                                                                                MaterialTheme
-                                                                                                        .typography
-                                                                                                        .titleMedium,
-                                                                                        fontWeight =
-                                                                                                FontWeight
-                                                                                                        .Bold,
-                                                                                        modifier =
-                                                                                                Modifier.padding(
-                                                                                                        bottom =
-                                                                                                                8.dp
-                                                                                        )
-                                                                                )
-
-                                                                                ExposedDropdownMenuBox(
-                                                                                        expanded =
-                                                                                                expandedAwayTeam,
-                                                                                        onExpandedChange = {
-                                                                                                expandedAwayTeam =
-                                                                                                        !expandedAwayTeam
-                                                                                        }
-                                                                                ) {
-                                                                                        OutlinedTextField(
-                                                                                                value =
-                                                                                                        selectedAwayTeam
-                                                                                                                ?.name
-                                                                                                        ?: "Away team",
-                                                                                                onValueChange = {
-                                                                                                },
-                                                                                                readOnly =
-                                                                                                        true,
-                                                                                                trailingIcon = {
-                                                                                                        ExposedDropdownMenuDefaults
-                                                                                                                .TrailingIcon(
-                                                                                                                expandedAwayTeam
-                                                                                                        )
-                                                                                                },
-                                                                                                modifier =
-                                                                                                        Modifier.fillMaxWidth()
-                                                                                                        .menuAnchor()
-                                                                                        )
-
-                                                                                        ExposedDropdownMenu(
-                                                                                                expanded =
-                                                                                                        expandedAwayTeam,
-                                                                                                onDismissRequest = {
-                                                                                                        expandedAwayTeam =
-                                                                                                                false
-                                                                                                }
-                                                                                        ) {
-                                                                                                availableTeams
-                                                                                                        .filter {
-                                                                                                                it !=
-                                                                                                                        selectedHomeTeam
-                                                                                                        }
-                                                                                                        .forEach {
-                                                                                                                team
-                                                                                                                ->
-                                                                                                                DropdownMenuItem(
-                                                                                                                        text = {
-                                                                                                                                Row(
-                                                                                                                                        verticalAlignment =
-                                                                                                                                                Alignment
-                                                                                                                                                        .CenterVertically
-                                                                                                                                ) {
-                                                                                                                                        team.localLogoRes
-                                                                                                                                                ?.let {
-                                                                                                                                                        logoRes
-                                                                                                                                                        ->
-                                                                                                                                                Image(
-                                                                                                                                                                painter =
-                                                                                                                                                                        painterResource(
-                                                                                                                                                                                id =
-                                                                                                                                                                                        logoRes
-                                                                                                                                                                        ),
-                                                                                                                                                                contentDescription =
-                                                                                                                                                                        team.name,
-                                                                                                                                                                modifier =
-                                                                                                                                                                        Modifier.size(
-                                                                                                                                                                24.dp
-                                                                                                                                                        )
-                                                                                                                                                )
-                                                                                                                                                Spacer(
-                                                                                                                                                                modifier =
-                                                                                                                                                                        Modifier.width(
-                                                                                                                                                                8.dp
-                                                                                                                                                        )
-                                                                                                                                                )
                                                                                                                                         }
-                                                                                                                                        Text(
-                                                                                                                                                team.name
-                                                                                                                                        )
+                                                                                                                                },
+                                                                                                                                // In the away team onClick:
+                                                                                                                                onClick = {
+                                                                                                                                        selectedAwayTeam =
+                                                                                                                                                team
+                                                                                                                                        expandedAwayTeam =
+                                                                                                                                                false
                                                                                                                                 }
-                                                                                                                        },
-                                                                                                                        // In the away team onClick:
-                                                                                                                        onClick = {
-                                                                                                                                selectedAwayTeam =
-                                                                                                                                        team
-                                                                                                                                expandedAwayTeam =
-                                                                                                                                        false
-                                                                                                                        }
-                                                                                                                )
-                                                                                                        }
+                                                                                                                        )
+                                                                                                                }
+                                                                                                }
                                                                                         }
                                                                                 }
                                                                         }
-                                                                }
 
-                                                                // --- Preview of selected match ---
-                                                                if (selectedHomeTeam != null &&
-                                                                                selectedAwayTeam !=
-                                                                                        null
-                                                                ) {
-                                                                        Spacer(
-                                                                                modifier =
-                                                                                        Modifier.height(
-                                                                                        16.dp
+                                                                        // --- Preview of selected
+                                                                        // match ---
+                                                                        if (selectedHomeTeam !=
+                                                                                        null &&
+                                                                                        selectedAwayTeam !=
+                                                                                                null
+                                                                        ) {
+                                                                                Spacer(
+                                                                                        modifier =
+                                                                                                Modifier.height(
+                                                                                                        16.dp
+                                                                                                )
                                                                                 )
-                                                                        )
-                                                                        TeamVsTeamDisplay(
-                                                                                homeTeamName =
-                                                                                        selectedHomeTeam!!
-                                                                                                .name,
-                                                                                awayTeamName =
-                                                                                        selectedAwayTeam!!
-                                                                                                .name
-                                                                        )
+                                                                                TeamVsTeamDisplay(
+                                                                                        homeTeamName =
+                                                                                                selectedHomeTeam!!
+                                                                                                        .name,
+                                                                                        awayTeamName =
+                                                                                                selectedAwayTeam!!
+                                                                                                        .name
+                                                                                )
+                                                                        }
                                                                 }
                                                         }
+                                                } // End AFL Match Selection
+                                        } // End AFL else block
+
+                                        // For F1, always show event info section
+                                        // For AFL, only show if not in live mode with no
+                                        // matches
+                                        val showEventInfoSection =
+                                                if (currentSelectedLeague == "F1") {
+                                                        // F1 events always show location and amenities
+                                                        true
+                                                } else {
+                                                        // AFL events: show location and amenities for both live and custom matches
+                                                        // This ensures the form sections are always visible for AFL
+                                                        true
                                                 }
 
-                                                val showEventInfoSection =
-                                                        (!isLiveMatchMode) ||
-                                                                (isLiveMatchMode &&
-                                                                        uiState.availableMatches
-                                                                                .isNotEmpty())
-
-                                                if (showEventInfoSection) {
-                                                        // Location
-                                                        EventFormSection(title = "Location") {
+                                        if (showEventInfoSection) {
+                                                // Location
+                                                EventFormSection(title = "Location") {
                                                                 OutlinedTextField(
                                                                         value =
                                                                                 formData.locationName,
                                                                         onValueChange = {
                                                                                 eventViewModel
                                                                                         .updateFormData(
-                                                                                        formData.copy(
+                                                                                                formData.copy(
                                                                                                         locationName =
                                                                                                                 it
                                                                                                 )
@@ -1385,7 +1802,7 @@ fun EventFormDialog(
                                                                         onValueChange = {
                                                                                 eventViewModel
                                                                                         .updateFormData(
-                                                                                        formData.copy(
+                                                                                                formData.copy(
                                                                                                         locationAddress =
                                                                                                                 it
                                                                                                 )
@@ -1410,11 +1827,11 @@ fun EventFormDialog(
                                                                         colors =
                                                                                 ButtonDefaults
                                                                                         .buttonColors(
-                                                                                        containerColor =
-                                                                                                MaterialTheme
-                                                                                                        .colorScheme
-                                                                                                        .primary
-                                                                                )
+                                                                                                containerColor =
+                                                                                                        MaterialTheme
+                                                                                                                .colorScheme
+                                                                                                                .primary
+                                                                                        )
                                                                 ) {
                                                                         Icon(
                                                                                 painter =
@@ -1433,8 +1850,8 @@ fun EventFormDialog(
                                                                         Spacer(
                                                                                 modifier =
                                                                                         Modifier.width(
-                                                                                        8.dp
-                                                                                )
+                                                                                                8.dp
+                                                                                        )
                                                                         )
                                                                         Text("Select Map Location")
                                                                 }
@@ -1450,11 +1867,11 @@ fun EventFormDialog(
                                                                                 colors =
                                                                                         CardDefaults
                                                                                                 .cardColors(
-                                                                                                containerColor =
-                                                                                                        MaterialTheme
-                                                                                                                .colorScheme
-                                                                                                                .surfaceVariant
-                                                                                        )
+                                                                                                        containerColor =
+                                                                                                                MaterialTheme
+                                                                                                                        .colorScheme
+                                                                                                                        .surfaceVariant
+                                                                                                )
                                                                         ) {
                                                                                 Column(
                                                                                         modifier =
@@ -1528,11 +1945,11 @@ fun EventFormDialog(
                                                                                                         ?: 0
                                                                                         eventViewModel
                                                                                                 .updateFormData(
-                                                                                                formData.copy(
+                                                                                                        formData.copy(
                                                                                                                 capacity =
                                                                                                                         capacityInt
+                                                                                                        )
                                                                                                 )
-                                                                                        )
                                                                                 }
                                                                         },
                                                                         label = {
@@ -1545,7 +1962,7 @@ fun EventFormDialog(
                                                                                         keyboardType =
                                                                                                 KeyboardType
                                                                                                         .Number
-                                                                        )
+                                                                                )
                                                                 )
 
                                                                 OutlinedTextField(
@@ -1554,11 +1971,11 @@ fun EventFormDialog(
                                                                         onValueChange = {
                                                                                 eventViewModel
                                                                                         .updateFormData(
-                                                                                        formData.copy(
+                                                                                                formData.copy(
                                                                                                         contactNumber =
                                                                                                                 it
+                                                                                                )
                                                                                         )
-                                                                                )
                                                                         },
                                                                         label = {
                                                                                 Text(
@@ -1595,15 +2012,15 @@ fun EventFormDialog(
                                                                         onCheckedChange = {
                                                                                 eventViewModel
                                                                                         .updateFormData(
-                                                                                        formData.copy(
-                                                                                                amenities =
-                                                                                                        formData.amenities
-                                                                                                                .copy(
-                                                                                                                        isIndoor =
-                                                                                                                                it
-                                                                                                                )
+                                                                                                formData.copy(
+                                                                                                        amenities =
+                                                                                                                formData.amenities
+                                                                                                                        .copy(
+                                                                                                                                isIndoor =
+                                                                                                                                        it
+                                                                                                                        )
+                                                                                                )
                                                                                         )
-                                                                                )
                                                                         },
                                                                         text = "Indoor"
                                                                 )
@@ -1615,15 +2032,15 @@ fun EventFormDialog(
                                                                         onCheckedChange = {
                                                                                 eventViewModel
                                                                                         .updateFormData(
-                                                                                        formData.copy(
-                                                                                                amenities =
-                                                                                                        formData.amenities
-                                                                                                                .copy(
-                                                                                                                        isOutdoor =
-                                                                                                                                it
-                                                                                                                )
+                                                                                                formData.copy(
+                                                                                                        amenities =
+                                                                                                                formData.amenities
+                                                                                                                        .copy(
+                                                                                                                                isOutdoor =
+                                                                                                                                        it
+                                                                                                                        )
+                                                                                                )
                                                                                         )
-                                                                                )
                                                                         },
                                                                         text = "Outdoor"
                                                                 )
@@ -1635,15 +2052,15 @@ fun EventFormDialog(
                                                                         onCheckedChange = {
                                                                                 eventViewModel
                                                                                         .updateFormData(
-                                                                                        formData.copy(
-                                                                                                amenities =
-                                                                                                        formData.amenities
-                                                                                                                .copy(
-                                                                                                                        isChildFriendly =
-                                                                                                                                it
-                                                                                                                )
+                                                                                                formData.copy(
+                                                                                                        amenities =
+                                                                                                                formData.amenities
+                                                                                                                        .copy(
+                                                                                                                                isChildFriendly =
+                                                                                                                                        it
+                                                                                                                        )
+                                                                                                )
                                                                                         )
-                                                                                )
                                                                         },
                                                                         text = "Child Friendly"
                                                                 )
@@ -1655,15 +2072,15 @@ fun EventFormDialog(
                                                                         onCheckedChange = {
                                                                                 eventViewModel
                                                                                         .updateFormData(
-                                                                                        formData.copy(
-                                                                                                amenities =
-                                                                                                        formData.amenities
-                                                                                                                .copy(
-                                                                                                                        isPetFriendly =
-                                                                                                                                it
-                                                                                                                )
+                                                                                                formData.copy(
+                                                                                                        amenities =
+                                                                                                                formData.amenities
+                                                                                                                        .copy(
+                                                                                                                                isPetFriendly =
+                                                                                                                                        it
+                                                                                                                        )
+                                                                                                )
                                                                                         )
-                                                                                )
                                                                         },
                                                                         text = "Pet Friendly"
                                                                 )
@@ -1675,15 +2092,15 @@ fun EventFormDialog(
                                                                         onCheckedChange = {
                                                                                 eventViewModel
                                                                                         .updateFormData(
-                                                                                        formData.copy(
-                                                                                                amenities =
-                                                                                                        formData.amenities
-                                                                                                                .copy(
-                                                                                                                        hasParking =
-                                                                                                                                it
-                                                                                                                )
+                                                                                                formData.copy(
+                                                                                                        amenities =
+                                                                                                                formData.amenities
+                                                                                                                        .copy(
+                                                                                                                                hasParking =
+                                                                                                                                        it
+                                                                                                                        )
+                                                                                                )
                                                                                         )
-                                                                                )
                                                                         },
                                                                         text = "Parking"
                                                                 )
@@ -1695,15 +2112,15 @@ fun EventFormDialog(
                                                                         onCheckedChange = {
                                                                                 eventViewModel
                                                                                         .updateFormData(
-                                                                                        formData.copy(
-                                                                                                amenities =
-                                                                                                        formData.amenities
-                                                                                                                .copy(
-                                                                                                                        hasFood =
-                                                                                                                                it
-                                                                                                                )
+                                                                                                formData.copy(
+                                                                                                        amenities =
+                                                                                                                formData.amenities
+                                                                                                                        .copy(
+                                                                                                                                hasFood =
+                                                                                                                                        it
+                                                                                                                        )
+                                                                                                )
                                                                                         )
-                                                                                )
                                                                         },
                                                                         text = "Food"
                                                                 )
@@ -1715,15 +2132,15 @@ fun EventFormDialog(
                                                                         onCheckedChange = {
                                                                                 eventViewModel
                                                                                         .updateFormData(
-                                                                                        formData.copy(
-                                                                                                amenities =
-                                                                                                        formData.amenities
-                                                                                                                .copy(
-                                                                                                                        hasToilet =
-                                                                                                                                it
-                                                                                                                )
+                                                                                                formData.copy(
+                                                                                                        amenities =
+                                                                                                                formData.amenities
+                                                                                                                        .copy(
+                                                                                                                                hasToilet =
+                                                                                                                                        it
+                                                                                                                        )
+                                                                                                )
                                                                                         )
-                                                                                )
                                                                         },
                                                                         text = "Toilet"
                                                                 )
@@ -1735,15 +2152,15 @@ fun EventFormDialog(
                                                                         onCheckedChange = {
                                                                                 eventViewModel
                                                                                         .updateFormData(
-                                                                                        formData.copy(
-                                                                                                amenities =
-                                                                                                        formData.amenities
-                                                                                                                .copy(
-                                                                                                                        hasWifi =
-                                                                                                                                it
-                                                                                                                )
+                                                                                                formData.copy(
+                                                                                                        amenities =
+                                                                                                                formData.amenities
+                                                                                                                        .copy(
+                                                                                                                                hasWifi =
+                                                                                                                                        it
+                                                                                                                        )
+                                                                                                )
                                                                                         )
-                                                                                )
                                                                         },
                                                                         text = "WiFi"
                                                                 )
@@ -1769,15 +2186,15 @@ fun EventFormDialog(
                                                                         onCheckedChange = {
                                                                                 eventViewModel
                                                                                         .updateFormData(
-                                                                                        formData.copy(
+                                                                                                formData.copy(
                                                                                                         accessibility =
                                                                                                                 formData.accessibility
                                                                                                                         .copy(
                                                                                                                                 isWheelchairAccessible =
                                                                                                                                         it
+                                                                                                                        )
                                                                                                 )
                                                                                         )
-                                                                                )
                                                                         },
                                                                         text =
                                                                                 "Wheelchair Accessible"
@@ -1790,99 +2207,100 @@ fun EventFormDialog(
                                                                         onCheckedChange = {
                                                                                 eventViewModel
                                                                                         .updateFormData(
-                                                                                        formData.copy(
-                                                                                                accessibility =
-                                                                                                        formData.accessibility
-                                                                                                                .copy(
-                                                                                                                        hasAccessibleToilets =
-                                                                                                                                it
-                                                                                                                )
+                                                                                                formData.copy(
+                                                                                                        accessibility =
+                                                                                                                formData.accessibility
+                                                                                                                        .copy(
+                                                                                                                                hasAccessibleToilets =
+                                                                                                                                        it
+                                                                                                                        )
+                                                                                                )
                                                                                         )
-                                                                                )
                                                                         },
                                                                         text = "Accessible Toilets"
                                                                 )
                                                         }
+                                        }
 
-                                                        // Footer buttons
-                                                        HorizontalDivider()
+                                        // Footer buttons
+                                        HorizontalDivider()
 
-                                                        Row(
-                                                                modifier =
-                                                                        Modifier.fillMaxWidth()
-                                                                        .padding(16.dp),
-                                                                horizontalArrangement =
-                                                                        Arrangement.spacedBy(8.dp)
-                                                        ) {
-                                                                OutlinedButton(
-                                                                        onClick = onDismiss,
-                                                                        modifier =
-                                                                                Modifier.weight(1f)
-                                                                ) { Text("Cancel") }
+                                        Row(
+                                                modifier =
+                                                        Modifier.fillMaxWidth()
+                                                                .padding(16.dp),
+                                                horizontalArrangement =
+                                                        Arrangement.spacedBy(8.dp)
+                                        ) {
+                                                OutlinedButton(
+                                                        onClick = onDismiss,
+                                                        modifier =
+                                                                Modifier.weight(1f)
+                                                ) { Text("Cancel") }
 
-                                                                Button(
-                                                                        onClick = {
-                                                                                if (!isLiveMatchMode &&
-                                                                                                selectedHomeTeam !=
-                                                                                                        null &&
-                                                                                                selectedAwayTeam !=
-                                                                                                        null
-                                                                                ) {
-                                                                                        eventViewModel
-                                                                                                .createCustomMatch(
-                                                                                                        selectedHomeTeam!!
-                                                                                                                .name,
-                                                                                                        selectedAwayTeam!!
-                                                                                                                .name
-                                                                                        )
-                                                                                }
-                                                                                onSave()
-                                                                        },
-                                                                        modifier =
-                                                                                Modifier.weight(1f),
-                                                                        enabled =
-                                                                                when {
-                                                                                        uiState.isLoading ->
-                                                                                                false
-                                                                                        isLiveMatchMode ->
-                                                                                                formData.selectedMatch !=
-                                                                                                        null &&
-                                                                                                        formData.locationName
-                                                                                                                .isNotBlank() &&
-                                                                                                        formData.locationAddress
-                                                                                                                .isNotBlank()
-                                                                                        else ->
-                                                                                                selectedHomeTeam !=
-                                                                                                        null &&
-                                                                                                        selectedAwayTeam !=
-                                                                                                                null && // Check local state for custom matches
-                                                                                                        formData.locationName
-                                                                                                                .isNotBlank() &&
-                                                                                                        formData.locationAddress
-                                                                                                                .isNotBlank()
-                                                                        }
+                                                Button(
+                                                        onClick = {
+                                                                // For F1, just save. For AFL, create custom match if needed
+                                                                if (currentSelectedLeague == "AFL" && 
+                                                                                isLiveMatchMode == false &&
+                                                                                selectedHomeTeam != null && 
+                                                                                selectedAwayTeam != null &&
+                                                                                formData.selectedMatch?.round != "Custom Match"
                                                                 ) {
-                                                                        if (uiState.isLoading) {
-                                                                                CircularProgressIndicator(
-                                                                                        modifier =
-                                                                                                Modifier.size(
-                                                                                                16.dp
-                                                                                        ),
-                                                                                        color =
-                                                                                                MaterialTheme
-                                                                                                        .colorScheme
-                                                                                                        .onPrimary
+                                                                        // Create custom match from selected teams
+                                                                        eventViewModel
+                                                                                .createCustomMatch(
+                                                                                        selectedHomeTeam!!.name,
+                                                                                        selectedAwayTeam!!.name
                                                                                 )
-                                                                        } else {
-                                                                                Text(
-                                                                                        if (isEditing
-                                                                                        )
-                                                                                                "Update"
-                                                                                        else
-                                                                                                "Create"
-                                                                                )
-                                                                        }
                                                                 }
+                                                                onSave()
+                                                        },
+                                                        modifier =
+                                                                Modifier.weight(1f),
+                                                        enabled =
+                                                                when {
+                                                                        uiState.isLoading ->
+                                                                                false
+                                                                        currentSelectedLeague == "F1" ->
+                                                                                formData.selectedMatch !=
+                                                                                        null &&
+                                                                                        formData.locationName
+                                                                                                .isNotBlank() &&
+                                                                                        formData.locationAddress
+                                                                                                .isNotBlank()
+                                                                        else ->
+                                                                                // AFL: check if match is selected OR teams are selected for custom match
+                                                                                (formData.selectedMatch != null || 
+                                                                                        (currentSelectedLeague == "AFL" && 
+                                                                                                isLiveMatchMode == false && 
+                                                                                                selectedHomeTeam != null && 
+                                                                                                selectedAwayTeam != null)) &&
+                                                                                        formData.locationName
+                                                                                                .isNotBlank() &&
+                                                                                        formData.locationAddress
+                                                                                                .isNotBlank()
+                                                                }
+                                                ) {
+                                                        if (uiState.isLoading) {
+                                                                CircularProgressIndicator(
+                                                                        modifier =
+                                                                                Modifier.size(
+                                                                                        16.dp
+                                                                                ),
+                                                                        color =
+                                                                                MaterialTheme
+                                                                                        .colorScheme
+                                                                                        .onPrimary
+                                                                )
+                                                        } else {
+                                                                Text(
+                                                                        if (isEditing
+                                                                        )
+                                                                                "Update"
+                                                                        else
+                                                                                "Create"
+                                                                )
                                                         }
                                                 }
                                         }

--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/component/NearbyMatchCard.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/component/NearbyMatchCard.kt
@@ -39,99 +39,118 @@ import java.util.Locale
 @Composable
 fun NearbyMatchCard(event: Event, onClick: () -> Unit) {
     Card(
-        onClick = onClick,
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(20.dp),
-        colors =
-            CardDefaults.cardColors(
-                containerColor = Color.White,
-                contentColor = MaterialTheme.colorScheme.onSurface
-            ),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+            onClick = onClick,
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(20.dp),
+            colors =
+                    CardDefaults.cardColors(
+                            containerColor = Color.White,
+                            contentColor = MaterialTheme.colorScheme.onSurface
+                    ),
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)),
+            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-        ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                // Teams Column (Left side)
-                Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                    // Home Team
+                // Teams Column (Left side) or F1 Grand Prix
+                val isF1Event = event.matchDetails?.competition == "F1"
+
+                if (isF1Event) {
+                    // F1 Event - Show F1 logo and Grand Prix name
                     Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.height(40.dp)
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.height(40.dp)
                     ) {
-                        TeamLogo(teamName = event.matchDetails?.homeTeam ?: "TBD")
-                        Spacer(modifier = Modifier.width(8.dp))
+                        androidx.compose.foundation.Image(
+                                painter = painterResource(id = R.drawable.league_f1),
+                                contentDescription = "F1",
+                                modifier = Modifier.size(40.dp)
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
                         Text(
-                            text = event.matchDetails?.homeTeam ?: "TBD",
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.Bold
+                                text = event.matchDetails?.venue ?: "F1 Grand Prix",
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.Bold
                         )
                     }
+                } else {
+                    // AFL Event - Show team logos
+                    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                        // Home Team
+                        Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.height(40.dp)
+                        ) {
+                            TeamLogo(teamName = event.matchDetails?.homeTeam ?: "TBD")
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                    text = event.matchDetails?.homeTeam ?: "TBD",
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    fontWeight = FontWeight.Bold
+                            )
+                        }
 
-                    // Away Team
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.height(40.dp)
-                    ) {
-                        TeamLogo(teamName = event.matchDetails?.awayTeam ?: "TBD")
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = event.matchDetails?.awayTeam ?: "TBD",
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.Bold
-                        )
+                        // Away Team
+                        Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.height(40.dp)
+                        ) {
+                            TeamLogo(teamName = event.matchDetails?.awayTeam ?: "TBD")
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                    text = event.matchDetails?.awayTeam ?: "TBD",
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    fontWeight = FontWeight.Bold
+                            )
+                        }
                     }
                 }
 
                 // Date and Time Column (Right side)
                 Column(
-                    horizontalAlignment = Alignment.End,
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                        horizontalAlignment = Alignment.End,
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     // Smart Date Display - Enhanced for today's events
                     val isToday = isEventToday(event.date)
                     Text(
-                        text = getSmartDateText(event.date),
-                        style =
-                            if (isToday) {
-                                MaterialTheme.typography.titleMedium
-                            } else {
-                                MaterialTheme.typography.bodyMedium
-                            },
-                        fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
-                        color =
-                            if (isToday) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.onSurfaceVariant
-                            }
+                            text = getSmartDateText(event.date),
+                            style =
+                                    if (isToday) {
+                                        MaterialTheme.typography.titleMedium
+                                    } else {
+                                        MaterialTheme.typography.bodyMedium
+                                    },
+                            fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
+                            color =
+                                    if (isToday) {
+                                        MaterialTheme.colorScheme.primary
+                                    } else {
+                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                    }
                     )
 
                     // Time - Enhanced for today's events
                     Text(
-                        text =
-                            SimpleDateFormat("HH:mm", Locale.getDefault())
-                                .format(event.checkInTime),
-                        style =
-                            if (isToday) {
-                                MaterialTheme.typography.titleMedium
-                            } else {
-                                MaterialTheme.typography.bodyMedium
-                            },
-                        fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
-                        color =
-                            if (isToday) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.primary
-                            }
+                            text =
+                                    SimpleDateFormat("HH:mm", Locale.getDefault())
+                                            .format(event.checkInTime),
+                            style =
+                                    if (isToday) {
+                                        MaterialTheme.typography.titleMedium
+                                    } else {
+                                        MaterialTheme.typography.bodyMedium
+                                    },
+                            fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal,
+                            color =
+                                    if (isToday) {
+                                        MaterialTheme.colorScheme.primary
+                                    } else {
+                                        MaterialTheme.colorScheme.primary
+                                    }
                     )
                 }
             }
@@ -140,23 +159,25 @@ fun NearbyMatchCard(event: Event, onClick: () -> Unit) {
 
             // Venue
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
             ) {
                 Box(
-                    modifier = Modifier
-                        .size(32.dp)
-                        .background(
-                            MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
-                            CircleShape
-                        ),
-                    contentAlignment = Alignment.Center
+                        modifier =
+                                Modifier.size(32.dp)
+                                        .background(
+                                                MaterialTheme.colorScheme.primary.copy(
+                                                        alpha = 0.1f
+                                                ),
+                                                CircleShape
+                                        ),
+                        contentAlignment = Alignment.Center
                 ) {
                     Icon(
-                        painter = painterResource(id = R.drawable.ic_location),
-                        contentDescription = "Location",
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(16.dp)
+                            painter = painterResource(id = R.drawable.ic_location),
+                            contentDescription = "Location",
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(16.dp)
                     )
                 }
 
@@ -164,24 +185,24 @@ fun NearbyMatchCard(event: Event, onClick: () -> Unit) {
 
                 Column {
                     Text(
-                        text = event.location.name,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium
+                            text = event.location.name,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium
                     )
                     Text(
-                        text = event.location.address,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                            text = event.location.address,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
 
                 if (event.accessibility.isWheelchairAccessible) {
                     Spacer(modifier = Modifier.weight(1f))
                     Icon(
-                        painter = painterResource(id = R.drawable.ic_accessible),
-                        contentDescription = "Wheelchair accessible",
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(20.dp)
+                            painter = painterResource(id = R.drawable.ic_accessible),
+                            contentDescription = "Wheelchair accessible",
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(20.dp)
                     )
                 }
             }
@@ -189,9 +210,9 @@ fun NearbyMatchCard(event: Event, onClick: () -> Unit) {
 
         // Bottom Divider
         HorizontalDivider(
-            color = MaterialTheme.colorScheme.surfaceVariant,
-            thickness = 1.dp,
-            modifier = Modifier.fillMaxWidth()
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                thickness = 1.dp,
+                modifier = Modifier.fillMaxWidth()
         )
     }
 }

--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/screen/ProfileLeagueSelectionScreen.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/screen/ProfileLeagueSelectionScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -19,156 +20,210 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.example.mobilecomputingassignment.R
-import androidx.compose.foundation.layout.statusBarsPadding
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ProfileLeagueSelectionScreen(
-    initialSelectedLeagues: Set<String> = emptySet(),
-    isLoading: Boolean = false,
-    onBackClick: () -> Unit,
-    onSaveClick: (List<String>) -> Unit,
-    modifier: Modifier = Modifier
+        initialSelectedLeagues: Set<String> = emptySet(),
+        isLoading: Boolean = false,
+        onBackClick: () -> Unit,
+        onSaveClick: (List<String>) -> Unit,
+        modifier: Modifier = Modifier
 ) {
-    var selectedLeagues by remember(initialSelectedLeagues) {
-        mutableStateOf(initialSelectedLeagues)
-    }
+    var selectedLeagues by
+            remember(initialSelectedLeagues) { mutableStateOf(initialSelectedLeagues) }
 
     // Use SAME Scaffold + TopAppBar pattern as other profile sub-screens
     Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Select League") },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                modifier = Modifier.statusBarsPadding()
-            )
-        },
-        bottomBar = {
-            // Show save button only if changes made
-            if (selectedLeagues != initialSelectedLeagues) {
-                Button(
-                    onClick = { onSaveClick(selectedLeagues.toList()) },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    enabled = !isLoading
-                ) {
-                    Text("Save Changes")
+            topBar = {
+                TopAppBar(
+                        title = { Text("Select League") },
+                        navigationIcon = {
+                            IconButton(onClick = onBackClick) {
+                                Icon(
+                                        Icons.AutoMirrored.Filled.ArrowBack,
+                                        contentDescription = "Back"
+                                )
+                            }
+                        },
+                        modifier = Modifier.statusBarsPadding()
+                )
+            },
+            bottomBar = {
+                // Show save button only if changes made
+                if (selectedLeagues != initialSelectedLeagues) {
+                    Button(
+                            onClick = { onSaveClick(selectedLeagues.toList()) },
+                            modifier = Modifier.fillMaxWidth().padding(16.dp),
+                            enabled = !isLoading
+                    ) { Text("Save Changes") }
                 }
             }
-        }
     ) { paddingValues ->
         Box(modifier = Modifier.padding(paddingValues).fillMaxSize()) {
             if (isLoading) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     CircularProgressIndicator()
                 }
             } else {
                 LazyColumn(
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier =
+                                Modifier.fillMaxSize().padding(horizontal = 16.dp, vertical = 8.dp)
                 ) {
                     // League selection grid (same as before)
-                    val availableLeagues = listOf("AFL", "A-League", "Premier League", "NBA")
-                    val enabledLeagues = setOf("AFL")
-                    val leagueImages = mapOf(
-                        "AFL" to R.drawable.league_afl,
-                        "A-League" to R.drawable.league_a_league,
-                        "Premier League" to R.drawable.league_premier_league,
-                        "NBA" to R.drawable.league_nba
-                    )
+                    val availableLeagues = listOf("AFL", "F1", "A-League", "Premier League", "NBA")
+                    val enabledLeagues = setOf("AFL", "F1")
+                    val leagueImages =
+                            mapOf(
+                                    "AFL" to R.drawable.league_afl,
+                                    "F1" to R.drawable.league_f1,
+                                    "A-League" to R.drawable.league_a_league,
+                                    "Premier League" to R.drawable.league_premier_league,
+                                    "NBA" to R.drawable.league_nba
+                            )
 
                     items(availableLeagues.chunked(3)) { leagueRow ->
                         Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
                             leagueRow.forEach { league ->
                                 val isEnabled = enabledLeagues.contains(league)
                                 val isSelected = selectedLeagues.contains(league)
 
                                 Card(
-                                    onClick = {
-                                        if (isEnabled) {
-                                            selectedLeagues = if (isSelected) {
-                                                selectedLeagues - league
-                                            } else {
-                                                selectedLeagues + league
+                                        onClick = {
+                                            if (isEnabled) {
+                                                selectedLeagues =
+                                                        if (isSelected) {
+                                                            selectedLeagues - league
+                                                        } else {
+                                                            selectedLeagues + league
+                                                        }
                                             }
-                                        }
-                                    },
-                                    modifier = Modifier.weight(1f).aspectRatio(1f),
-                                    shape = RoundedCornerShape(12.dp),
-                                    colors = CardDefaults.cardColors(
-                                        containerColor = when {
-                                            isSelected && isEnabled -> MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)
-                                            isEnabled -> MaterialTheme.colorScheme.surface
-                                            else -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
-                                        }
-                                    ),
-                                    border = when {
-                                        isSelected && isEnabled -> BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
-                                        isEnabled -> BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.2f))
-                                        else -> BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.05f))
-                                    }
+                                        },
+                                        modifier = Modifier.weight(1f).aspectRatio(1f),
+                                        shape = RoundedCornerShape(12.dp),
+                                        colors =
+                                                CardDefaults.cardColors(
+                                                        containerColor =
+                                                                when {
+                                                                    isSelected && isEnabled ->
+                                                                            MaterialTheme
+                                                                                    .colorScheme
+                                                                                    .primary.copy(
+                                                                                    alpha = 0.1f
+                                                                            )
+                                                                    isEnabled ->
+                                                                            MaterialTheme
+                                                                                    .colorScheme
+                                                                                    .surface
+                                                                    else ->
+                                                                            MaterialTheme
+                                                                                    .colorScheme
+                                                                                    .surfaceVariant
+                                                                                    .copy(
+                                                                                            alpha =
+                                                                                                    0.3f
+                                                                                    )
+                                                                }
+                                                ),
+                                        border =
+                                                when {
+                                                    isSelected && isEnabled ->
+                                                            BorderStroke(
+                                                                    2.dp,
+                                                                    MaterialTheme.colorScheme
+                                                                            .primary
+                                                            )
+                                                    isEnabled ->
+                                                            BorderStroke(
+                                                                    1.dp,
+                                                                    MaterialTheme.colorScheme
+                                                                            .outline.copy(
+                                                                            alpha = 0.2f
+                                                                    )
+                                                            )
+                                                    else ->
+                                                            BorderStroke(
+                                                                    1.dp,
+                                                                    MaterialTheme.colorScheme
+                                                                            .outline.copy(
+                                                                            alpha = 0.05f
+                                                                    )
+                                                            )
+                                                }
                                 ) {
                                     Column(
-                                        modifier = Modifier.fillMaxSize().padding(12.dp),
-                                        horizontalAlignment = Alignment.CenterHorizontally,
-                                        verticalArrangement = Arrangement.Center
+                                            modifier = Modifier.fillMaxSize().padding(12.dp),
+                                            horizontalAlignment = Alignment.CenterHorizontally,
+                                            verticalArrangement = Arrangement.Center
                                     ) {
                                         leagueImages[league]?.let { imageRes ->
                                             Image(
-                                                painter = painterResource(id = imageRes),
-                                                contentDescription = "$league logo",
-                                                modifier = Modifier.size(48.dp).weight(1f),
-                                                colorFilter = if (!isEnabled) ColorFilter.colorMatrix(
-                                                    ColorMatrix().apply { setToSaturation(0f) }
-                                                ) else null,
-                                                alpha = if (!isEnabled) 0.4f else 1f
+                                                    painter = painterResource(id = imageRes),
+                                                    contentDescription = "$league logo",
+                                                    modifier = Modifier.size(48.dp).weight(1f),
+                                                    colorFilter =
+                                                            if (!isEnabled)
+                                                                    ColorFilter.colorMatrix(
+                                                                            ColorMatrix().apply {
+                                                                                setToSaturation(0f)
+                                                                            }
+                                                                    )
+                                                            else null,
+                                                    alpha = if (!isEnabled) 0.4f else 1f
                                             )
-                                        } ?: Box(
-                                            modifier = Modifier.size(48.dp).weight(1f)
-                                                .background(
-                                                    MaterialTheme.colorScheme.surfaceVariant,
-                                                    RoundedCornerShape(8.dp)
-                                                ),
-                                            contentAlignment = Alignment.Center
-                                        ) {
-                                            Text(league.take(3), style = MaterialTheme.typography.labelMedium)
                                         }
+                                                ?: Box(
+                                                        modifier =
+                                                                Modifier.size(48.dp)
+                                                                        .weight(1f)
+                                                                        .background(
+                                                                                MaterialTheme
+                                                                                        .colorScheme
+                                                                                        .surfaceVariant,
+                                                                                RoundedCornerShape(
+                                                                                        8.dp
+                                                                                )
+                                                                        ),
+                                                        contentAlignment = Alignment.Center
+                                                ) {
+                                                    Text(
+                                                            league.take(3),
+                                                            style =
+                                                                    MaterialTheme.typography
+                                                                            .labelMedium
+                                                    )
+                                                }
 
                                         Spacer(modifier = Modifier.height(8.dp))
                                         Text(
-                                            text = league,
-                                            style = MaterialTheme.typography.bodySmall,
-                                            textAlign = TextAlign.Center,
-                                            maxLines = 2,
-                                            color = when {
-                                                isSelected && isEnabled -> MaterialTheme.colorScheme.primary
-                                                isEnabled -> MaterialTheme.colorScheme.onSurface
-                                                else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
-                                            }
+                                                text = league,
+                                                style = MaterialTheme.typography.bodySmall,
+                                                textAlign = TextAlign.Center,
+                                                maxLines = 2,
+                                                color =
+                                                        when {
+                                                            isSelected && isEnabled ->
+                                                                    MaterialTheme.colorScheme
+                                                                            .primary
+                                                            isEnabled ->
+                                                                    MaterialTheme.colorScheme
+                                                                            .onSurface
+                                                            else ->
+                                                                    MaterialTheme.colorScheme
+                                                                            .onSurfaceVariant.copy(
+                                                                            alpha = 0.3f
+                                                                    )
+                                                        }
                                         )
                                     }
                                 }
                             }
 
-                            repeat(3 - leagueRow.size) {
-                                Spacer(modifier = Modifier.weight(1f))
-                            }
+                            repeat(3 - leagueRow.size) { Spacer(modifier = Modifier.weight(1f)) }
                         }
                     }
                 }

--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/screen/SignupSteps.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/ui/screen/SignupSteps.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -13,8 +14,9 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.material3.DatePicker
-import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.*
 import androidx.compose.runtime.getValue
@@ -35,10 +37,6 @@ import com.example.mobilecomputingassignment.R
 import com.example.mobilecomputingassignment.domain.models.Team
 import com.example.mobilecomputingassignment.presentation.viewmodel.AuthUiState
 import java.util.Calendar
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.TopAppBar
-import androidx.compose.foundation.layout.statusBarsPadding
 
 enum class PasswordStrength {
     WEAK,
@@ -47,49 +45,47 @@ enum class PasswordStrength {
 
 @Composable
 fun SignupEmailStep(
-    onNextClick: (String) -> Unit,
-    onBackClick: () -> Unit,
-    isLoading: Boolean,
-    errorMessage: String?,
-    initialEmail: String = "",
-    onEmailChange: ((String) -> Unit)? = null
+        onNextClick: (String) -> Unit,
+        onBackClick: () -> Unit,
+        isLoading: Boolean,
+        errorMessage: String?,
+        initialEmail: String = "",
+        onEmailChange: ((String) -> Unit)? = null
 ) {
     var email by remember { mutableStateOf(initialEmail) }
 
     SignupLayout(
-        title = "Enter your email",
-        subtitle = "We'll check if this email is available",
-        onBackClick = onBackClick,
-        currentStep = 1,
-        totalSteps = 6,
-        buttonText = "Next",
-        buttonEnabled = email.isNotEmpty() && errorMessage == null,
-        isLoading = isLoading,
-        onButtonClick = { onNextClick(email) },
-        errorMessage = errorMessage
+            title = "Enter your email",
+            subtitle = "We'll check if this email is available",
+            onBackClick = onBackClick,
+            currentStep = 1,
+            totalSteps = 6,
+            buttonText = "Next",
+            buttonEnabled = email.isNotEmpty() && errorMessage == null,
+            isLoading = isLoading,
+            onButtonClick = { onNextClick(email) },
+            errorMessage = errorMessage
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             OutlinedTextField(
-                value = email,
-                onValueChange = {
-                    email = it
-                    onEmailChange?.invoke(it)
-                },
-                label = { Text("Email Address") },
-                leadingIcon = {
-                    Icon(Icons.Default.Email, contentDescription = null)
-                },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true,
-                isError = errorMessage != null
+                    value = email,
+                    onValueChange = {
+                        email = it
+                        onEmailChange?.invoke(it)
+                    },
+                    label = { Text("Email Address") },
+                    leadingIcon = { Icon(Icons.Default.Email, contentDescription = null) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    isError = errorMessage != null
             )
 
             if (errorMessage != null) {
                 Text(
-                    text = errorMessage,
-                    color = MaterialTheme.colorScheme.error,
-                    style = MaterialTheme.typography.bodySmall
+                        text = errorMessage,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall
                 )
             }
         }
@@ -98,11 +94,11 @@ fun SignupEmailStep(
 
 @Composable
 fun SignupPasswordStep(
-    onNextClick: (String, String) -> Unit,
-    onBackClick: () -> Unit,
-    errorMessage: String?,
-    initialPassword: String = "",
-    initialConfirmPassword: String = ""
+        onNextClick: (String, String) -> Unit,
+        onBackClick: () -> Unit,
+        errorMessage: String?,
+        initialPassword: String = "",
+        initialConfirmPassword: String = ""
 ) {
     var password by remember { mutableStateOf(initialPassword) }
     var confirmPassword by remember { mutableStateOf(initialConfirmPassword) }
@@ -110,85 +106,78 @@ fun SignupPasswordStep(
     var confirmPasswordVisible by remember { mutableStateOf(false) }
 
     val passwordStrength =
-        remember(password) {
-            when {
-                password.length < 7 -> PasswordStrength.WEAK
-                !password.any { it.isUpperCase() } -> PasswordStrength.WEAK
-                !password.any { it.isDigit() } -> PasswordStrength.WEAK
-                else -> PasswordStrength.STRONG
+            remember(password) {
+                when {
+                    password.length < 7 -> PasswordStrength.WEAK
+                    !password.any { it.isUpperCase() } -> PasswordStrength.WEAK
+                    !password.any { it.isDigit() } -> PasswordStrength.WEAK
+                    else -> PasswordStrength.STRONG
+                }
             }
-        }
 
     val passwordsMatch =
-        password.isNotEmpty() && confirmPassword.isNotEmpty() && password == confirmPassword
+            password.isNotEmpty() && confirmPassword.isNotEmpty() && password == confirmPassword
     val isFormValid = passwordStrength == PasswordStrength.STRONG && passwordsMatch
 
     SignupLayout(
-        title = "Create a password",
-        subtitle = "Your password must be at least 7 characters with 1 capital letter and 1 number",
-        onBackClick = onBackClick,
-        currentStep = 2,
-        totalSteps = 6,
-        buttonText = "Next",
-        buttonEnabled = isFormValid,
-        onButtonClick = { onNextClick(password, confirmPassword) },
-        errorMessage = errorMessage
+            title = "Create a password",
+            subtitle =
+                    "Your password must be at least 7 characters with 1 capital letter and 1 number",
+            onBackClick = onBackClick,
+            currentStep = 2,
+            totalSteps = 6,
+            buttonText = "Next",
+            buttonEnabled = isFormValid,
+            onButtonClick = { onNextClick(password, confirmPassword) },
+            errorMessage = errorMessage
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedTextField(
-                    value = password,
-                    onValueChange = { password = it },
-                    label = { Text("Password") },
-                    leadingIcon = {
-                        Icon(Icons.Default.Lock, contentDescription = null)
-                    },
-                    trailingIcon = {
-                        IconButton(
-                            onClick = {
-                                passwordVisible = !passwordVisible
+                        value = password,
+                        onValueChange = { password = it },
+                        label = { Text("Password") },
+                        leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
+                        trailingIcon = {
+                            IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                                Icon(
+                                        painter =
+                                                painterResource(
+                                                        if (passwordVisible)
+                                                                R.drawable.visibility_icon
+                                                        else R.drawable.visibility_off_icon
+                                                ),
+                                        contentDescription =
+                                                if (passwordVisible) "Hide password"
+                                                else "Show password"
+                                )
                             }
-                        ) {
-                            Icon(
-                                painter =
-                                    painterResource(
-                                        if (passwordVisible) R.drawable.visibility_icon
-                                        else R.drawable.visibility_off_icon
-                                    ),
-                                contentDescription =
-                                    if (passwordVisible) "Hide password"
-                                    else "Show password"
-                            )
-                        }
-                    },
-                    visualTransformation =
-                        if (passwordVisible) VisualTransformation.None
-                        else PasswordVisualTransformation(),
-                    keyboardOptions =
-                        KeyboardOptions(
-                            keyboardType = KeyboardType.Password
-                        ),
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    isError =
-                        errorMessage != null ||
-                                (password.isNotEmpty() &&
-                                        passwordStrength == PasswordStrength.WEAK)
+                        },
+                        visualTransformation =
+                                if (passwordVisible) VisualTransformation.None
+                                else PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        isError =
+                                errorMessage != null ||
+                                        (password.isNotEmpty() &&
+                                                passwordStrength == PasswordStrength.WEAK)
                 )
 
                 if (password.isNotEmpty()) {
                     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                         PasswordRequirement(
-                            text = "At least 7 characters",
-                            isMet = password.length >= 7
+                                text = "At least 7 characters",
+                                isMet = password.length >= 7
                         )
                         PasswordRequirement(
-                            text = "Contains uppercase letter",
-                            isMet = password.any { it.isUpperCase() }
+                                text = "Contains uppercase letter",
+                                isMet = password.any { it.isUpperCase() }
                         )
                         PasswordRequirement(
-                            text = "Contains number",
-                            isMet = password.any { it.isDigit() }
+                                text = "Contains number",
+                                isMet = password.any { it.isDigit() }
                         )
                     }
                 }
@@ -196,69 +185,63 @@ fun SignupPasswordStep(
 
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedTextField(
-                    value = confirmPassword,
-                    onValueChange = { confirmPassword = it },
-                    label = { Text("Confirm Password") },
-                    leadingIcon = {
-                        Icon(Icons.Default.Lock, contentDescription = null)
-                    },
-                    trailingIcon = {
-                        IconButton(
-                            onClick = {
-                                confirmPasswordVisible = !confirmPasswordVisible
+                        value = confirmPassword,
+                        onValueChange = { confirmPassword = it },
+                        label = { Text("Confirm Password") },
+                        leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) },
+                        trailingIcon = {
+                            IconButton(
+                                    onClick = { confirmPasswordVisible = !confirmPasswordVisible }
+                            ) {
+                                Icon(
+                                        painter =
+                                                painterResource(
+                                                        if (confirmPasswordVisible)
+                                                                R.drawable.visibility_icon
+                                                        else R.drawable.visibility_off_icon
+                                                ),
+                                        contentDescription =
+                                                if (confirmPasswordVisible) "Hide password"
+                                                else "Show password"
+                                )
                             }
-                        ) {
-                            Icon(
-                                painter =
-                                    painterResource(
-                                        if (confirmPasswordVisible) R.drawable.visibility_icon
-                                        else R.drawable.visibility_off_icon
-                                    ),
-                                contentDescription =
-                                    if (confirmPasswordVisible) "Hide password"
-                                    else "Show password"
-                            )
-                        }
-                    },
-                    visualTransformation =
-                        if (confirmPasswordVisible) VisualTransformation.None
-                        else PasswordVisualTransformation(),
-                    keyboardOptions =
-                        KeyboardOptions(
-                            keyboardType = KeyboardType.Password
-                        ),
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    isError =
-                        errorMessage != null ||
-                                (confirmPassword.isNotEmpty() &&
-                                        password.isNotEmpty() &&
-                                        !passwordsMatch)
+                        },
+                        visualTransformation =
+                                if (confirmPasswordVisible) VisualTransformation.None
+                                else PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        isError =
+                                errorMessage != null ||
+                                        (confirmPassword.isNotEmpty() &&
+                                                password.isNotEmpty() &&
+                                                !passwordsMatch)
                 )
 
                 if (confirmPassword.isNotEmpty() && password.isNotEmpty()) {
                     Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         Icon(
-                            imageVector =
-                                if (passwordsMatch) Icons.Default.Check
-                                else Icons.Default.Close,
-                            contentDescription = null,
-                            tint =
-                                if (passwordsMatch) MaterialTheme.colorScheme.primary
-                                else MaterialTheme.colorScheme.error,
-                            modifier = Modifier.size(16.dp)
+                                imageVector =
+                                        if (passwordsMatch) Icons.Default.Check
+                                        else Icons.Default.Close,
+                                contentDescription = null,
+                                tint =
+                                        if (passwordsMatch) MaterialTheme.colorScheme.primary
+                                        else MaterialTheme.colorScheme.error,
+                                modifier = Modifier.size(16.dp)
                         )
                         Text(
-                            text =
-                                if (passwordsMatch) "Passwords match"
-                                else "Passwords don't match",
-                            style = MaterialTheme.typography.bodySmall,
-                            color =
-                                if (passwordsMatch) MaterialTheme.colorScheme.primary
-                                else MaterialTheme.colorScheme.error
+                                text =
+                                        if (passwordsMatch) "Passwords match"
+                                        else "Passwords don't match",
+                                style = MaterialTheme.typography.bodySmall,
+                                color =
+                                        if (passwordsMatch) MaterialTheme.colorScheme.primary
+                                        else MaterialTheme.colorScheme.error
                         )
                     }
                 }
@@ -270,23 +253,23 @@ fun SignupPasswordStep(
 @Composable
 private fun PasswordRequirement(text: String, isMet: Boolean) {
     Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         Icon(
-            imageVector = if (isMet) Icons.Default.Check else Icons.Default.Close,
-            contentDescription = null,
-            tint =
-                if (isMet) MaterialTheme.colorScheme.primary
-                else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-            modifier = Modifier.size(16.dp)
+                imageVector = if (isMet) Icons.Default.Check else Icons.Default.Close,
+                contentDescription = null,
+                tint =
+                        if (isMet) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                modifier = Modifier.size(16.dp)
         )
         Text(
-            text = text,
-            style = MaterialTheme.typography.bodySmall,
-            color =
-                if (isMet) MaterialTheme.colorScheme.primary
-                else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                text = text,
+                style = MaterialTheme.typography.bodySmall,
+                color =
+                        if (isMet) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
         )
     }
 }
@@ -316,15 +299,15 @@ fun calculateAge(birthdateString: String): Int {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SignupUsernameAndAgeStep(
-    onNextClick: (String, String, Boolean) -> Unit,
-    onBackClick: () -> Unit,
-    isLoading: Boolean,
-    errorMessage: String?,
-    initialUsername: String = "",
-    initialBirthdate: String = "",
-    initialAgeConfirmed: Boolean = false,
-    onUsernameChange: ((String) -> Unit)? = null,
-    uiState: AuthUiState
+        onNextClick: (String, String, Boolean) -> Unit,
+        onBackClick: () -> Unit,
+        isLoading: Boolean,
+        errorMessage: String?,
+        initialUsername: String = "",
+        initialBirthdate: String = "",
+        initialAgeConfirmed: Boolean = false,
+        onUsernameChange: ((String) -> Unit)? = null,
+        uiState: AuthUiState
 ) {
     var username by remember { mutableStateOf(initialUsername) }
     var birthdate by remember { mutableStateOf(initialBirthdate) }
@@ -332,201 +315,213 @@ fun SignupUsernameAndAgeStep(
     var showDatePicker by remember { mutableStateOf(false) }
 
     val calculatedAge = calculateAge(birthdate)
-    val isBirthdateValidAndOldEnough = calculatedAge >= 18 && birthdate.matches(Regex("""\d{2}/\d{2}/\d{4}"""))
+    val isBirthdateValidAndOldEnough =
+            calculatedAge >= 18 && birthdate.matches(Regex("""\d{2}/\d{2}/\d{4}"""))
 
     val isFormValid =
-        username.length >= 3 &&
-                isBirthdateValidAndOldEnough &&
-                ageConfirmed &&
-                (errorMessage == null || !errorMessage.contains("username", ignoreCase = true))
+            username.length >= 3 &&
+                    isBirthdateValidAndOldEnough &&
+                    ageConfirmed &&
+                    (errorMessage == null || !errorMessage.contains("username", ignoreCase = true))
 
     SignupLayout(
-        title = "Complete your profile",
-        subtitle = "Enter your username and birthdate to continue",
-        onBackClick = onBackClick,
-        currentStep = 3,
-        totalSteps = 6,
-        buttonText = "Next",
-        buttonEnabled = isFormValid,
-        isLoading = isLoading,
-        onButtonClick = { onNextClick(username, birthdate, ageConfirmed) },
-        errorMessage = errorMessage
+            title = "Complete your profile",
+            subtitle = "Enter your username and birthdate to continue",
+            onBackClick = onBackClick,
+            currentStep = 3,
+            totalSteps = 6,
+            buttonText = "Next",
+            buttonEnabled = isFormValid,
+            isLoading = isLoading,
+            onButtonClick = { onNextClick(username, birthdate, ageConfirmed) },
+            errorMessage = errorMessage
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedTextField(
-                    value = username,
-                    onValueChange = {
-                        username = it
-                        onUsernameChange?.invoke(it)
-                    },
-                    label = { Text("Username") },
-                    leadingIcon = {
-                        Icon(Icons.Default.Person, contentDescription = null)
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    isError =
-                        (errorMessage != null && errorMessage.contains("username", ignoreCase = true)) ||
-                                (username.isNotEmpty() && username.length < 3)
+                        value = username,
+                        onValueChange = {
+                            username = it
+                            onUsernameChange?.invoke(it)
+                        },
+                        label = { Text("Username") },
+                        leadingIcon = { Icon(Icons.Default.Person, contentDescription = null) },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        isError =
+                                (errorMessage != null &&
+                                        errorMessage.contains("username", ignoreCase = true)) ||
+                                        (username.isNotEmpty() && username.length < 3)
                 )
                 if (username.isNotEmpty() && username.length < 3) {
                     Text(
-                        text = "Username must be at least 3 characters",
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodySmall
+                            text = "Username must be at least 3 characters",
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
                     )
                 }
                 if (errorMessage != null && errorMessage.contains("username", ignoreCase = true)) {
                     Text(
-                        text = errorMessage,
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodySmall
+                            text = errorMessage,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
                     )
                 }
             }
 
             OutlinedTextField(
-                value = birthdate,
-                onValueChange = { newValue ->
-                    // Allow typing but validate the format
-                    if (newValue.length <= 10) { // Limit to DD/MM/YYYY format length
-                        birthdate = newValue
-                    }
-                },
-                label = { Text("Birthdate (DD/MM/YYYY)") },
-                leadingIcon = {
-                    IconButton(onClick = { showDatePicker = true }) {
-                        Icon(
-                            Icons.Default.DateRange,
-                            contentDescription = "Select birthdate",
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                },
-//                placeholder = { Text("01/01/2000") },
-                modifier = Modifier.fillMaxWidth(),
-                readOnly = false, // ✅ CHANGED: Now allows typing
-                singleLine = true,
-                isError = birthdate.isNotEmpty() && !birthdate.matches(Regex("""\d{2}/\d{2}/\d{4}"""))
-                // No trailingIcon - only the clickable leading icon
-            )
-
-
+                    value = birthdate,
+                    onValueChange = { newValue ->
+                        // Allow typing but validate the format
+                        if (newValue.length <= 10) { // Limit to DD/MM/YYYY format length
+                            birthdate = newValue
+                        }
+                    },
+                    label = { Text("Birthdate (DD/MM/YYYY)") },
+                    leadingIcon = {
+                        IconButton(onClick = { showDatePicker = true }) {
+                            Icon(
+                                    Icons.Default.DateRange,
+                                    contentDescription = "Select birthdate",
+                                    tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    },
+                    //                placeholder = { Text("01/01/2000") },
+                    modifier = Modifier.fillMaxWidth(),
+                    readOnly = false, // ✅ CHANGED: Now allows typing
+                    singleLine = true,
+                    isError =
+                            birthdate.isNotEmpty() &&
+                                    !birthdate.matches(Regex("""\d{2}/\d{2}/\d{4}"""))
+                    // No trailingIcon - only the clickable leading icon
+                    )
 
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 Checkbox(
-                    checked = ageConfirmed,
-                    onCheckedChange = { ageConfirmed = it },
-                    enabled = isBirthdateValidAndOldEnough
+                        checked = ageConfirmed,
+                        onCheckedChange = { ageConfirmed = it },
+                        enabled = isBirthdateValidAndOldEnough
                 )
                 Text(
-                    text = "I confirm that I am 18 years or older",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = if (isBirthdateValidAndOldEnough) MaterialTheme.colorScheme.onSurface
-                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+                        text = "I confirm that I am 18 years or older",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color =
+                                if (isBirthdateValidAndOldEnough)
+                                        MaterialTheme.colorScheme.onSurface
+                                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
                 )
             }
-            if (birthdate.isNotEmpty() && !isBirthdateValidAndOldEnough && calculatedAge < 18 && calculatedAge != 0) {
+            if (birthdate.isNotEmpty() &&
+                            !isBirthdateValidAndOldEnough &&
+                            calculatedAge < 18 &&
+                            calculatedAge != 0
+            ) {
                 Text(
-                    text = "You must be 18 years or older to sign up.",
-                    color = MaterialTheme.colorScheme.error,
-                    style = MaterialTheme.typography.bodySmall
+                        text = "You must be 18 years or older to sign up.",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall
                 )
             }
         }
     }
 
     if (showDatePicker) {
-        val datePickerState = rememberDatePickerState(
-            initialSelectedDateMillis = if (birthdate.isNotEmpty()) {
-                try {
-                    val parts = birthdate.split("/")
-                    if (parts.size == 3) {
-                        val day = parts[0].toInt()
-                        val month = parts[1].toInt() - 1
-                        val year = parts[2].toInt()
-                        java.util.Calendar.getInstance().apply {
-                            set(year, month, day)
-                        }.timeInMillis
-                    } else null
-                } catch (e: Exception) {
-                    null
-                }
-            } else null
-        )
+        val datePickerState =
+                rememberDatePickerState(
+                        initialSelectedDateMillis =
+                                if (birthdate.isNotEmpty()) {
+                                    try {
+                                        val parts = birthdate.split("/")
+                                        if (parts.size == 3) {
+                                            val day = parts[0].toInt()
+                                            val month = parts[1].toInt() - 1
+                                            val year = parts[2].toInt()
+                                            java.util.Calendar.getInstance()
+                                                    .apply { set(year, month, day) }
+                                                    .timeInMillis
+                                        } else null
+                                    } catch (e: Exception) {
+                                        null
+                                    }
+                                } else null
+                )
 
         DatePickerDialog(
-            onDismissRequest = { showDatePicker = false },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        datePickerState.selectedDateMillis?.let { millis ->
-                            val calendar = java.util.Calendar.getInstance()
-                            calendar.timeInMillis = millis
-                            val day = calendar.get(java.util.Calendar.DAY_OF_MONTH)
-                            val month = calendar.get(java.util.Calendar.MONTH) + 1
-                            val year = calendar.get(java.util.Calendar.YEAR)
-                            birthdate = String.format("%02d/%02d/%04d", day, month, year)
-                        }
-                        showDatePicker = false
-                    },
-                    colors = ButtonDefaults.textButtonColors(
-                        contentColor = MaterialTheme.colorScheme.primary
-                    )
-                ) { Text("OK") }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = { showDatePicker = false },
-                    colors = ButtonDefaults.textButtonColors(
-                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                ) { Text("Cancel") }
-            },
-            colors = DatePickerDefaults.colors(
-                containerColor = MaterialTheme.colorScheme.surface,
-                titleContentColor = MaterialTheme.colorScheme.onSurface,
-                headlineContentColor = MaterialTheme.colorScheme.onSurface,
-                weekdayContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                subheadContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                yearContentColor = MaterialTheme.colorScheme.onSurface,
-                currentYearContentColor = MaterialTheme.colorScheme.primary,
-                selectedYearContentColor = MaterialTheme.colorScheme.onPrimary,
-                selectedYearContainerColor = MaterialTheme.colorScheme.primary,
-                dayContentColor = MaterialTheme.colorScheme.onSurface,
-                disabledDayContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-                selectedDayContentColor = MaterialTheme.colorScheme.onPrimary,
-                disabledSelectedDayContentColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.38f),
-                selectedDayContainerColor = MaterialTheme.colorScheme.primary,
-                disabledSelectedDayContainerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
-                todayContentColor = MaterialTheme.colorScheme.primary,
-                todayDateBorderColor = MaterialTheme.colorScheme.primary,
-                dayInSelectionRangeContentColor = MaterialTheme.colorScheme.onPrimary,
-                dayInSelectionRangeContainerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
-            )
-        ) {
-            DatePicker(
-                state = datePickerState,
-                showModeToggle = false
-            )
-        }
+                onDismissRequest = { showDatePicker = false },
+                confirmButton = {
+                    TextButton(
+                            onClick = {
+                                datePickerState.selectedDateMillis?.let { millis ->
+                                    val calendar = java.util.Calendar.getInstance()
+                                    calendar.timeInMillis = millis
+                                    val day = calendar.get(java.util.Calendar.DAY_OF_MONTH)
+                                    val month = calendar.get(java.util.Calendar.MONTH) + 1
+                                    val year = calendar.get(java.util.Calendar.YEAR)
+                                    birthdate = String.format("%02d/%02d/%04d", day, month, year)
+                                }
+                                showDatePicker = false
+                            },
+                            colors =
+                                    ButtonDefaults.textButtonColors(
+                                            contentColor = MaterialTheme.colorScheme.primary
+                                    )
+                    ) { Text("OK") }
+                },
+                dismissButton = {
+                    TextButton(
+                            onClick = { showDatePicker = false },
+                            colors =
+                                    ButtonDefaults.textButtonColors(
+                                            contentColor =
+                                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                    ) { Text("Cancel") }
+                },
+                colors =
+                        DatePickerDefaults.colors(
+                                containerColor = MaterialTheme.colorScheme.surface,
+                                titleContentColor = MaterialTheme.colorScheme.onSurface,
+                                headlineContentColor = MaterialTheme.colorScheme.onSurface,
+                                weekdayContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                subheadContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                yearContentColor = MaterialTheme.colorScheme.onSurface,
+                                currentYearContentColor = MaterialTheme.colorScheme.primary,
+                                selectedYearContentColor = MaterialTheme.colorScheme.onPrimary,
+                                selectedYearContainerColor = MaterialTheme.colorScheme.primary,
+                                dayContentColor = MaterialTheme.colorScheme.onSurface,
+                                disabledDayContentColor =
+                                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+                                selectedDayContentColor = MaterialTheme.colorScheme.onPrimary,
+                                disabledSelectedDayContentColor =
+                                        MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.38f),
+                                selectedDayContainerColor = MaterialTheme.colorScheme.primary,
+                                disabledSelectedDayContainerColor =
+                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+                                todayContentColor = MaterialTheme.colorScheme.primary,
+                                todayDateBorderColor = MaterialTheme.colorScheme.primary,
+                                dayInSelectionRangeContentColor =
+                                        MaterialTheme.colorScheme.onPrimary,
+                                dayInSelectionRangeContainerColor =
+                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+                        )
+        ) { DatePicker(state = datePickerState, showModeToggle = false) }
     }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SignupLeagueStep(
-    onNextClick: (List<String>) -> Unit,
-    onSkipClick: () -> Unit,
-    onBackClick: () -> Unit,
-    initialSelectedLeagues: Set<String> = emptySet(),
-    isEditingMode: Boolean = false,
-    onSaveLeagues: ((List<String>) -> Unit)? = null
+        onNextClick: (List<String>) -> Unit,
+        onSkipClick: () -> Unit,
+        onBackClick: () -> Unit,
+        initialSelectedLeagues: Set<String> = emptySet(),
+        isEditingMode: Boolean = false,
+        onSaveLeagues: ((List<String>) -> Unit)? = null
 ) {
     var selectedLeagues by remember { mutableStateOf(initialSelectedLeagues) }
 
@@ -545,111 +540,159 @@ fun SignupLeagueStep(
 
     // Use SignupLayout for consistency with other signup steps
     SignupLayout(
-        title = actualTitle,
-        subtitle = actualSubtitle,
-        onBackClick = onBackClick,
-        currentStep = if (isEditingMode) 0 else 4,
-        totalSteps = if (isEditingMode) 0 else 6,
-        buttonText = actualButtonText,
-        buttonEnabled = true,
-        onButtonClick = actualOnButtonClick,
-        showSkip = !isEditingMode,
-        onSkipClick = if (!isEditingMode) onSkipClick else null,
-        isEditingMode = isEditingMode
+            title = actualTitle,
+            subtitle = actualSubtitle,
+            onBackClick = onBackClick,
+            currentStep = if (isEditingMode) 0 else 4,
+            totalSteps = if (isEditingMode) 0 else 6,
+            buttonText = actualButtonText,
+            buttonEnabled = true,
+            onButtonClick = actualOnButtonClick,
+            showSkip = !isEditingMode,
+            onSkipClick = if (!isEditingMode) onSkipClick else null,
+            isEditingMode = isEditingMode
     ) {
         // League selection content
-        val availableLeagues = listOf("AFL", "A-League", "Premier League", "NBA")
-        val enabledLeagues = setOf("AFL")
-        val leagueImages = mapOf(
-            "AFL" to R.drawable.league_afl,
-            "A-League" to R.drawable.league_a_league,
-            "Premier League" to R.drawable.league_premier_league,
-            "NBA" to R.drawable.league_nba
-        )
+        val availableLeagues = listOf("AFL", "F1", "A-League", "Premier League", "NBA")
+        val enabledLeagues = setOf("AFL", "F1")
+        val leagueImages =
+                mapOf(
+                        "AFL" to R.drawable.league_afl,
+                        "F1" to R.drawable.league_f1,
+                        "A-League" to R.drawable.league_a_league,
+                        "Premier League" to R.drawable.league_premier_league,
+                        "NBA" to R.drawable.league_nba
+                )
 
         LazyColumn(
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.heightIn(min = 200.dp, max = 400.dp)
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.heightIn(min = 200.dp, max = 400.dp)
         ) {
             items(availableLeagues.chunked(3)) { leagueRow ->
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     leagueRow.forEach { league ->
                         val isEnabled = enabledLeagues.contains(league)
                         val isSelected = selectedLeagues.contains(league)
 
                         Card(
-                            onClick = {
-                                if (isEnabled) {
-                                    selectedLeagues = if (isSelected) {
-                                        selectedLeagues - league
-                                    } else {
-                                        selectedLeagues + league
+                                onClick = {
+                                    if (isEnabled) {
+                                        selectedLeagues =
+                                                if (isSelected) {
+                                                    selectedLeagues - league
+                                                } else {
+                                                    selectedLeagues + league
+                                                }
                                     }
-                                }
-                            },
-                            modifier = Modifier.weight(1f).aspectRatio(1f),
-                            shape = RoundedCornerShape(12.dp),
-                            colors = CardDefaults.cardColors(
-                                containerColor = when {
-                                    isSelected && isEnabled -> MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)
-                                    isEnabled -> MaterialTheme.colorScheme.surface
-                                    else -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
-                                }
-                            ),
-                            border = when {
-                                isSelected && isEnabled -> BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
-                                isEnabled -> BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.2f))
-                                else -> BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.05f))
-                            }
+                                },
+                                modifier = Modifier.weight(1f).aspectRatio(1f),
+                                shape = RoundedCornerShape(12.dp),
+                                colors =
+                                        CardDefaults.cardColors(
+                                                containerColor =
+                                                        when {
+                                                            isSelected && isEnabled ->
+                                                                    MaterialTheme.colorScheme
+                                                                            .primary.copy(
+                                                                            alpha = 0.1f
+                                                                    )
+                                                            isEnabled ->
+                                                                    MaterialTheme.colorScheme
+                                                                            .surface
+                                                            else ->
+                                                                    MaterialTheme.colorScheme
+                                                                            .surfaceVariant.copy(
+                                                                            alpha = 0.3f
+                                                                    )
+                                                        }
+                                        ),
+                                border =
+                                        when {
+                                            isSelected && isEnabled ->
+                                                    BorderStroke(
+                                                            2.dp,
+                                                            MaterialTheme.colorScheme.primary
+                                                    )
+                                            isEnabled ->
+                                                    BorderStroke(
+                                                            1.dp,
+                                                            MaterialTheme.colorScheme.outline.copy(
+                                                                    alpha = 0.2f
+                                                            )
+                                                    )
+                                            else ->
+                                                    BorderStroke(
+                                                            1.dp,
+                                                            MaterialTheme.colorScheme.outline.copy(
+                                                                    alpha = 0.05f
+                                                            )
+                                                    )
+                                        }
                         ) {
                             Column(
-                                modifier = Modifier.fillMaxSize().padding(12.dp),
-                                horizontalAlignment = Alignment.CenterHorizontally,
-                                verticalArrangement = Arrangement.Center
+                                    modifier = Modifier.fillMaxSize().padding(12.dp),
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                    verticalArrangement = Arrangement.Center
                             ) {
                                 leagueImages[league]?.let { imageRes ->
                                     Image(
-                                        painter = painterResource(id = imageRes),
-                                        contentDescription = "$league logo",
-                                        modifier = Modifier.size(48.dp).weight(1f),
-                                        colorFilter = if (!isEnabled) ColorFilter.colorMatrix(
-                                            ColorMatrix().apply { setToSaturation(0f) }
-                                        ) else null,
-                                        alpha = if (!isEnabled) 0.4f else 1f
+                                            painter = painterResource(id = imageRes),
+                                            contentDescription = "$league logo",
+                                            modifier = Modifier.size(48.dp).weight(1f),
+                                            colorFilter =
+                                                    if (!isEnabled)
+                                                            ColorFilter.colorMatrix(
+                                                                    ColorMatrix().apply {
+                                                                        setToSaturation(0f)
+                                                                    }
+                                                            )
+                                                    else null,
+                                            alpha = if (!isEnabled) 0.4f else 1f
                                     )
-                                } ?: Box(
-                                    modifier = Modifier.size(48.dp).weight(1f)
-                                        .background(
-                                            MaterialTheme.colorScheme.surfaceVariant,
-                                            RoundedCornerShape(8.dp)
-                                        ),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    Text(league.take(3), style = MaterialTheme.typography.labelMedium)
                                 }
+                                        ?: Box(
+                                                modifier =
+                                                        Modifier.size(48.dp)
+                                                                .weight(1f)
+                                                                .background(
+                                                                        MaterialTheme.colorScheme
+                                                                                .surfaceVariant,
+                                                                        RoundedCornerShape(8.dp)
+                                                                ),
+                                                contentAlignment = Alignment.Center
+                                        ) {
+                                            Text(
+                                                    league.take(3),
+                                                    style = MaterialTheme.typography.labelMedium
+                                            )
+                                        }
 
                                 Spacer(modifier = Modifier.height(8.dp))
                                 Text(
-                                    text = league,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    textAlign = TextAlign.Center,
-                                    maxLines = 2,
-                                    color = when {
-                                        isSelected && isEnabled -> MaterialTheme.colorScheme.primary
-                                        isEnabled -> MaterialTheme.colorScheme.onSurface
-                                        else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.3f)
-                                    }
+                                        text = league,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        textAlign = TextAlign.Center,
+                                        maxLines = 2,
+                                        color =
+                                                when {
+                                                    isSelected && isEnabled ->
+                                                            MaterialTheme.colorScheme.primary
+                                                    isEnabled -> MaterialTheme.colorScheme.onSurface
+                                                    else ->
+                                                            MaterialTheme.colorScheme
+                                                                    .onSurfaceVariant.copy(
+                                                                    alpha = 0.3f
+                                                            )
+                                                }
                                 )
                             }
                         }
                     }
 
-                    repeat(3 - leagueRow.size) {
-                        Spacer(modifier = Modifier.weight(1f))
-                    }
+                    repeat(3 - leagueRow.size) { Spacer(modifier = Modifier.weight(1f)) }
                 }
             }
         }
@@ -658,12 +701,12 @@ fun SignupLeagueStep(
 
 @Composable
 fun SignupTeamStep(
-    onNextClick: (List<String>) -> Unit,
-    onSkipClick: () -> Unit,
-    onBackClick: () -> Unit,
-    availableTeams: List<Team> = emptyList(),
-    isLoadingTeams: Boolean = false,
-    onLoadTeams: () -> Unit = {}
+        onNextClick: (List<String>) -> Unit,
+        onSkipClick: () -> Unit,
+        onBackClick: () -> Unit,
+        availableTeams: List<Team> = emptyList(),
+        isLoadingTeams: Boolean = false,
+        onLoadTeams: () -> Unit = {}
 ) {
     var selectedTeams by remember { mutableStateOf(setOf<String>()) }
 
@@ -674,89 +717,116 @@ fun SignupTeamStep(
     }
 
     SignupLayout(
-        title = "Pick your favorite teams",
-        subtitle = "This is to help recommend watch alongs for you",
-        onBackClick = onBackClick,
-        currentStep = 5,
-        totalSteps = 6,
-        buttonText = "Complete",
-        buttonEnabled = true,
-        onButtonClick = { onNextClick(selectedTeams.toList()) },
-        showSkip = true,
-        onSkipClick = onSkipClick
+            title = "Pick your favorite teams",
+            subtitle = "This is to help recommend watch alongs for you",
+            onBackClick = onBackClick,
+            currentStep = 5,
+            totalSteps = 6,
+            buttonText = "Complete",
+            buttonEnabled = true,
+            onButtonClick = { onNextClick(selectedTeams.toList()) },
+            showSkip = true,
+            onSkipClick = onSkipClick
     ) {
         if (isLoadingTeams) {
-            Box(modifier = Modifier.fillMaxWidth().height(320.dp), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator()
-            }
+            Box(
+                    modifier = Modifier.fillMaxWidth().height(320.dp),
+                    contentAlignment = Alignment.Center
+            ) { CircularProgressIndicator() }
         } else {
             LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.heightIn(min = 200.dp, max = 320.dp)
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.heightIn(min = 200.dp, max = 320.dp)
             ) {
                 items(availableTeams.chunked(3)) { teamRow ->
                     Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         teamRow.forEach { team ->
                             val isSelected = selectedTeams.contains(team.name)
                             Card(
-                                onClick = {
-                                    selectedTeams =
-                                        if (isSelected) selectedTeams - team.name
-                                        else selectedTeams + team.name
-                                },
-                                modifier = Modifier.weight(1f).aspectRatio(1f),
-                                shape = RoundedCornerShape(12.dp),
-                                colors = CardDefaults.cardColors(
-                                    containerColor = if (isSelected) MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)
-                                    else MaterialTheme.colorScheme.surface
-                                ),
-                                border = if (isSelected) BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
-                                else BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.2f))
+                                    onClick = {
+                                        selectedTeams =
+                                                if (isSelected) selectedTeams - team.name
+                                                else selectedTeams + team.name
+                                    },
+                                    modifier = Modifier.weight(1f).aspectRatio(1f),
+                                    shape = RoundedCornerShape(12.dp),
+                                    colors =
+                                            CardDefaults.cardColors(
+                                                    containerColor =
+                                                            if (isSelected)
+                                                                    MaterialTheme.colorScheme
+                                                                            .primary.copy(
+                                                                            alpha = 0.1f
+                                                                    )
+                                                            else MaterialTheme.colorScheme.surface
+                                            ),
+                                    border =
+                                            if (isSelected)
+                                                    BorderStroke(
+                                                            2.dp,
+                                                            MaterialTheme.colorScheme.primary
+                                                    )
+                                            else
+                                                    BorderStroke(
+                                                            1.dp,
+                                                            MaterialTheme.colorScheme.outline.copy(
+                                                                    alpha = 0.2f
+                                                            )
+                                                    )
                             ) {
                                 Column(
-                                    modifier = Modifier.fillMaxSize().padding(12.dp),
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                    verticalArrangement = Arrangement.Center
+                                        modifier = Modifier.fillMaxSize().padding(12.dp),
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        verticalArrangement = Arrangement.Center
                                 ) {
                                     if (team.localLogoRes != null) {
                                         Image(
-                                            painter = painterResource(id = team.localLogoRes),
-                                            contentDescription = "${team.name} logo",
-                                            modifier = Modifier.size(48.dp).weight(1f)
+                                                painter = painterResource(id = team.localLogoRes),
+                                                contentDescription = "${team.name} logo",
+                                                modifier = Modifier.size(48.dp).weight(1f)
                                         )
                                     } else if (!team.logoUrl.isNullOrEmpty()) {
                                         AsyncImage(
-                                            model = team.logoUrl,
-                                            contentDescription = "${team.name} logo",
-                                            modifier = Modifier.size(48.dp).weight(1f)
+                                                model = team.logoUrl,
+                                                contentDescription = "${team.name} logo",
+                                                modifier = Modifier.size(48.dp).weight(1f)
                                         )
                                     } else {
                                         Box(
-                                            modifier = Modifier.size(48.dp).weight(1f)
-                                                .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(8.dp)),
-                                            contentAlignment = Alignment.Center
+                                                modifier =
+                                                        Modifier.size(48.dp)
+                                                                .weight(1f)
+                                                                .background(
+                                                                        MaterialTheme.colorScheme
+                                                                                .surfaceVariant,
+                                                                        RoundedCornerShape(8.dp)
+                                                                ),
+                                                contentAlignment = Alignment.Center
                                         ) {
-                                            Text(team.abbreviation.ifEmpty { team.name.take(3) }, style = MaterialTheme.typography.labelMedium)
+                                            Text(
+                                                    team.abbreviation.ifEmpty { team.name.take(3) },
+                                                    style = MaterialTheme.typography.labelMedium
+                                            )
                                         }
                                     }
                                     Spacer(modifier = Modifier.height(8.dp))
                                     Text(
-                                        text = team.name,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        textAlign = TextAlign.Center,
-                                        maxLines = 2,
-                                        color = if (isSelected) MaterialTheme.colorScheme.primary
-                                        else MaterialTheme.colorScheme.onSurface
+                                            text = team.name,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            textAlign = TextAlign.Center,
+                                            maxLines = 2,
+                                            color =
+                                                    if (isSelected)
+                                                            MaterialTheme.colorScheme.primary
+                                                    else MaterialTheme.colorScheme.onSurface
                                     )
                                 }
                             }
                         }
-                        repeat(3 - teamRow.size) {
-                            Spacer(modifier = Modifier.weight(1f))
-                        }
+                        repeat(3 - teamRow.size) { Spacer(modifier = Modifier.weight(1f)) }
                     }
                 }
             }
@@ -766,95 +836,106 @@ fun SignupTeamStep(
 
 @Composable
 fun SignupLayout(
-    title: String,
-    subtitle: String,
-    onBackClick: () -> Unit,
-    currentStep: Int,
-    totalSteps: Int,
-    buttonText: String,
-    buttonEnabled: Boolean,
-    onButtonClick: () -> Unit,
-    isLoading: Boolean = false,
-    errorMessage: String? = null,
-    showSkip: Boolean = false,
-    onSkipClick: (() -> Unit)? = null,
-    isEditingMode: Boolean = false,
-    content: @Composable () -> Unit
+        title: String,
+        subtitle: String,
+        onBackClick: () -> Unit,
+        currentStep: Int,
+        totalSteps: Int,
+        buttonText: String,
+        buttonEnabled: Boolean,
+        onButtonClick: () -> Unit,
+        isLoading: Boolean = false,
+        errorMessage: String? = null,
+        showSkip: Boolean = false,
+        onSkipClick: (() -> Unit)? = null,
+        isEditingMode: Boolean = false,
+        content: @Composable () -> Unit
 ) {
     Column(modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp)) {
         SignupHeader(
-            onBackClick = onBackClick,
-            currentStep = currentStep,
-            totalSteps = totalSteps,
-            isEditingMode = isEditingMode
+                onBackClick = onBackClick,
+                currentStep = currentStep,
+                totalSteps = totalSteps,
+                isEditingMode = isEditingMode
         )
 
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(24.dp)
-        ) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(24.dp)) {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(text = title, style = MaterialTheme.typography.headlineMedium)
                 Text(
-                    text = subtitle,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
             content()
             if (errorMessage != null &&
-                !errorMessage.contains("email", ignoreCase = true) &&
-                !errorMessage.contains("username", ignoreCase = true) &&
-                !errorMessage.contains("password", ignoreCase = true)
+                            !errorMessage.contains("email", ignoreCase = true) &&
+                            !errorMessage.contains("username", ignoreCase = true) &&
+                            !errorMessage.contains("password", ignoreCase = true)
             ) {
                 Text(
-                    text = errorMessage,
-                    color = MaterialTheme.colorScheme.error,
-                    style = MaterialTheme.typography.bodyMedium
+                        text = errorMessage,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyMedium
                 )
             }
         }
 
         Column(
-            modifier = Modifier.padding(bottom = 32.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+                modifier = Modifier.padding(bottom = 32.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             if (showSkip && onSkipClick != null && !isEditingMode) {
                 Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     Button(
-                        onClick = onButtonClick,
-                        enabled = buttonEnabled && !isLoading,
-                        modifier = Modifier.fillMaxWidth().height(40.dp),
-                        shape = RoundedCornerShape(16.dp)
+                            onClick = onButtonClick,
+                            enabled = buttonEnabled && !isLoading,
+                            modifier = Modifier.fillMaxWidth().height(40.dp),
+                            shape = RoundedCornerShape(16.dp)
                     ) {
                         if (isLoading) {
-                            CircularProgressIndicator(modifier = Modifier.size(20.dp), color = MaterialTheme.colorScheme.onPrimary)
+                            CircularProgressIndicator(
+                                    modifier = Modifier.size(20.dp),
+                                    color = MaterialTheme.colorScheme.onPrimary
+                            )
                         } else {
-                            Text(buttonText, style = MaterialTheme.typography.labelLarge, fontSize = 16.sp)
+                            Text(
+                                    buttonText,
+                                    style = MaterialTheme.typography.labelLarge,
+                                    fontSize = 16.sp
+                            )
                         }
                     }
                     OutlinedButton(
-                        onClick = onSkipClick,
-                        modifier = Modifier.fillMaxWidth().height(40.dp),
-                        shape = RoundedCornerShape(16.dp)
+                            onClick = onSkipClick,
+                            modifier = Modifier.fillMaxWidth().height(40.dp),
+                            shape = RoundedCornerShape(16.dp)
                     ) {
                         Text("Skip", style = MaterialTheme.typography.labelLarge, fontSize = 16.sp)
                     }
                 }
             } else {
                 Button(
-                    onClick = onButtonClick,
-                    enabled = buttonEnabled && !isLoading,
-                    modifier = Modifier.fillMaxWidth().height(40.dp),
-                    shape = RoundedCornerShape(16.dp)
+                        onClick = onButtonClick,
+                        enabled = buttonEnabled && !isLoading,
+                        modifier = Modifier.fillMaxWidth().height(40.dp),
+                        shape = RoundedCornerShape(16.dp)
                 ) {
                     if (isLoading) {
-                        CircularProgressIndicator(modifier = Modifier.size(20.dp), color = MaterialTheme.colorScheme.onPrimary)
+                        CircularProgressIndicator(
+                                modifier = Modifier.size(20.dp),
+                                color = MaterialTheme.colorScheme.onPrimary
+                        )
                     } else {
-                        Text(buttonText, style = MaterialTheme.typography.labelLarge, fontSize = 16.sp)
+                        Text(
+                                buttonText,
+                                style = MaterialTheme.typography.labelLarge,
+                                fontSize = 16.sp
+                        )
                     }
                 }
             }
@@ -864,21 +945,16 @@ fun SignupLayout(
 
 @Composable
 fun SignupHeader(
-    onBackClick: () -> Unit,
-    currentStep: Int,
-    totalSteps: Int,
-    isEditingMode: Boolean = false
+        onBackClick: () -> Unit,
+        currentStep: Int,
+        totalSteps: Int,
+        isEditingMode: Boolean = false
 ) {
     Column(
-        modifier = Modifier
-            .padding(vertical = 16.dp)
-            .statusBarsPadding(),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+            modifier = Modifier.padding(vertical = 16.dp).statusBarsPadding(),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
             IconButton(onClick = onBackClick) {
                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
             }
@@ -886,18 +962,18 @@ fun SignupHeader(
             if (!isEditingMode && currentStep > 0 && totalSteps > 0) {
                 Spacer(modifier = Modifier.weight(1f))
                 Text(
-                    text = "$currentStep of $totalSteps",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                        text = "$currentStep of $totalSteps",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }
 
         if (!isEditingMode && currentStep > 0 && totalSteps > 0) {
             LinearProgressIndicator(
-                progress = currentStep.toFloat() / totalSteps.toFloat(),
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.primary
+                    progress = currentStep.toFloat() / totalSteps.toFloat(),
+                    modifier = Modifier.fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.primary
             )
         }
     }

--- a/app/src/main/java/com/example/mobilecomputingassignment/presentation/utils/CustomMarkerIconGenerator.kt
+++ b/app/src/main/java/com/example/mobilecomputingassignment/presentation/utils/CustomMarkerIconGenerator.kt
@@ -53,7 +53,8 @@ object CustomMarkerIconGenerator {
         val matchDetails = event.matchDetails
 
         return if (matchDetails != null) {
-            // Determine if this is an AFL event
+            // Determine if this is an AFL event (show team logos)
+            // For F1 and other leagues, show league logo
             if (matchDetails.competition.equals("AFL", ignoreCase = true)) {
                 generateAFLTeamMarker(context, event)
             } else {
@@ -86,6 +87,7 @@ object CustomMarkerIconGenerator {
         val leagueLogoRes =
                 when (competition.uppercase()) {
                     "AFL" -> R.drawable.league_afl
+                    "F1" -> R.drawable.league_f1
                     "A-LEAGUE" -> R.drawable.league_a_league
                     "PREMIER LEAGUE" -> R.drawable.league_premier_league
                     "NBA" -> R.drawable.league_nba


### PR DESCRIPTION
Introduces support for F1 events alongside AFL, including league selection in the event form, F1 Grand Prix selection, and UI updates to display F1 branding and details in event cards, dialogs, and match detail drawers. Updates TeamConstants to include F1 as an available league and provides a list of 2024 F1 Grand Prix events. UI components now conditionally render F1 or AFL-specific visuals and data based on the selected league.